### PR TITLE
set body margin to 0 to avoid screen flicker/horizontal scroll bar

### DIFF
--- a/src/Service.Host/client/src/index.js
+++ b/src/Service.Host/client/src/index.js
@@ -34,6 +34,8 @@ const render = Component => {
     );
 };
 
+document.body.style.margin = '0';
+
 if ((!user || user.expired) && window.location.pathname !== '/purchasing/signin-oidc-client') {
     userManager.signinRedirect({
         data: { redirect: window.location.pathname + window.location.search }


### PR DESCRIPTION
margin is set by something to 8px causing horizontal scrollbar to appear, in stores is overridden but not sure what by. We could figure it out if anyone has any ideas or we can just do this and set it to 0 manually.
Stores from dev tools:
![image](https://user-images.githubusercontent.com/51612225/154682096-52bf4fff-2524-44fc-ab17-920e6be429f2.png)
and purchasing with this change in dev tools:
![image](https://user-images.githubusercontent.com/51612225/154682258-9f854689-e83e-4873-80e6-26f751c830e6.png)
