### PR TITLE
OB Previous PR Changes

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrders/OverbookAllowedByLog.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/OverbookAllowedByLog.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Linn.Common.Domain;
+
     public class OverbookAllowedByLog : LogTable
     {
         public int Id { get; set; }
@@ -13,7 +14,5 @@
         public DateTime OverbookDate { get; set; }
 
         public decimal? OverbookQty { get; set; }
-
-        public int OrderLine { get; set; }
     }
 }

--- a/src/Facade/Services/PurchaseOrderFacadeService.cs
+++ b/src/Facade/Services/PurchaseOrderFacadeService.cs
@@ -45,9 +45,7 @@
             {
                 LogAction = actionType,
                 LogTime = DateTime.UtcNow,
-                LogUserNumber = userNumber,
                 OrderNumber = entity.OrderNumber,
-                OrderLine = 1,
                 OverbookQty = entity.OverbookQty,
                 OverbookDate = DateTime.Now,
                 OverbookGrantedBy = userNumber

--- a/src/Persistence.LinnApps/Repositories/OverbookAllowedByLogRespository.cs
+++ b/src/Persistence.LinnApps/Repositories/OverbookAllowedByLogRespository.cs
@@ -19,7 +19,6 @@
         public override void Add(OverbookAllowedByLog entity)
         {
             entity.Id = this.databaseService.GetIdSequence("AN_ARBITRARY_SEQUENCE");
-            entity.LogId = entity.Id;
             this.serviceDbContext.AllowOverbookLogs.Add(entity);
         }
     }

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -532,11 +532,11 @@
         {
             var entity = builder.Entity<OverbookAllowedByLog>().ToTable("PL_OVERBOOK_ALLOWED_BY");
             entity.HasKey(a => a.Id);
+            entity.Property(o => o.OverbookGrantedBy).HasColumnName("ID").HasMaxLength(8);
             entity.Property(o => o.OrderNumber).HasColumnName("ORDER_NUMBER");
             entity.Property(o => o.OverbookGrantedBy).HasColumnName("OVERBOOK_GRANTED_BY").HasMaxLength(6);
             entity.Property(o => o.OverbookDate).HasColumnName("OVERBOOK_DATE");
             entity.Property(o => o.OverbookGrantedBy).HasColumnName("OVERBOOK_QTY").HasMaxLength(14);
-            entity.Property(o => o.OverbookGrantedBy).HasColumnName("ORDER_LINE").HasMaxLength(6);
         }
 
         private void BuildSigningLimits(ModelBuilder builder)

--- a/tests/Integration/Integration.Tests/PurchaseOrderModuletests/WhenGettingPurchaseOrder.cs
+++ b/tests/Integration/Integration.Tests/PurchaseOrderModuletests/WhenGettingPurchaseOrder.cs
@@ -1,6 +1,4 @@
-﻿using Linn.Common.Facade;
-
-namespace Linn.Purchasing.Integration.Tests.PurchaseOrderModuleTests
+﻿namespace Linn.Purchasing.Integration.Tests.PurchaseOrderModuleTests
 {
     using System.Collections.Generic;
     using System.Net;
@@ -8,6 +6,7 @@ namespace Linn.Purchasing.Integration.Tests.PurchaseOrderModuleTests
     using FluentAssertions;
     using FluentAssertions.Extensions;
 
+    using Linn.Common.Facade;
     using Linn.Purchasing.Domain.LinnApps.PurchaseOrders;
     using Linn.Purchasing.Integration.Tests.Extensions;
     using Linn.Purchasing.Resources;
@@ -19,12 +18,12 @@ namespace Linn.Purchasing.Integration.Tests.PurchaseOrderModuleTests
     public class WhenGettingPurchaseOrder : ContextBase
     {
         private PurchaseOrder req;
-        private int orderNumberSearch;
+        private int orderNumber;
 
         [SetUp]
         public void SetUp()
         {
-            this.orderNumberSearch = 600179;
+            this.orderNumber = 600179;
             this.req = new PurchaseOrder()
                            {
                                OrderNumber = 600179,
@@ -36,7 +35,7 @@ namespace Linn.Purchasing.Integration.Tests.PurchaseOrderModuleTests
                                SupplierId = 1224
             };
 
-            this.PurchaseOrderFacadeService.GetById(this.orderNumberSearch, Arg.Any<IEnumerable<string>>())
+            this.PurchaseOrderFacadeService.GetById(this.orderNumber, Arg.Any<IEnumerable<string>>())
                 .ReturnsForAnyArgs(
                     new SuccessResult<PurchaseOrderResource>(
                         new PurchaseOrderResource
@@ -47,7 +46,7 @@ namespace Linn.Purchasing.Integration.Tests.PurchaseOrderModuleTests
                         }));
 
             this.Response = this.Client.Get(
-                $"/purchasing/purchase-orders/{this.orderNumberSearch}",
+                $"/purchasing/purchase-orders/{this.orderNumber}",
                 with =>
                 {
                     with.Accept("application/json");


### PR DESCRIPTION
Example search result : http://localhost:3000/purchasing/purchase-orders/6667/allow-over-book
Search page : http://localhost:3000/purchasing/purchase-orders/

These are the changes suggested in the previous PR (but were lost due to a Git error) : https://github.com/linn/purchasing/pull/145 

I've tried manually changing LogAction to be an "Insert" rather than an "Update" but I'm still not seeing anything in PL_OVERBOOK_ALLOWED_BY. There's definitely just something I'm missing here, would appreciate another set of eyes on it.