### PR TITLE
use better balance between quality and speed to avoid long waits

### DIFF
--- a/src/Service.Host/client/src/helpers/pdf.js
+++ b/src/Service.Host/client/src/helpers/pdf.js
@@ -13,7 +13,7 @@ export const savePdf = async ref => {
     const pdfWidth = pdf.internal.pageSize.getWidth();
     const pdfHeight = (imgProperties.height * pdfWidth) / imgProperties.width;
 
-    pdf.addImage(data, 'jpeg', 0, 0, pdfWidth, pdfHeight, '', 'FAST');
+    pdf.addImage(data, 'JPEG', 0, 0, pdfWidth, pdfHeight, '', 'FAST');
     pdf.save();
 };
 
@@ -23,14 +23,14 @@ export const emailPdf = async (ref, sendEmailCallback) => {
         quality: 5,
         scale: 2
     });
-    const data = canvas.toDataURL('image/png');
+    const data = canvas.toDataURL('image/jpeg');
 
     const pdf = new JsPDF('p', 'pt', 'a4', true);
     const imgProperties = pdf.getImageProperties(data);
     const pdfWidth = pdf.internal.pageSize.getWidth();
     const pdfHeight = (imgProperties.height * pdfWidth) / imgProperties.width;
 
-    pdf.addImage(data, 'PNG', 0, 0, pdfWidth, pdfHeight, '', 'FAST');
+    pdf.addImage(data, 'JPEG', 0, 0, pdfWidth, pdfHeight, '', 'FAST');
 
     const blob = pdf.output('blob');
     sendEmailCallback(blob);

--- a/src/Service.Host/client/src/helpers/pdf.js
+++ b/src/Service.Host/client/src/helpers/pdf.js
@@ -4,25 +4,24 @@ import { jsPDF as JsPDF } from 'jspdf';
 export const savePdf = async ref => {
     const element = ref.current;
     const canvas = await html2canvas(element, {
-        quality: 4,
-        scale: 5
+        quality: 5,
+        scale: 2
     });
-    const data = canvas.toDataURL('image/png');
-
+    const data = canvas.toDataURL('image/jpeg');
     const pdf = new JsPDF('p', 'pt', 'a4', true);
     const imgProperties = pdf.getImageProperties(data);
     const pdfWidth = pdf.internal.pageSize.getWidth();
     const pdfHeight = (imgProperties.height * pdfWidth) / imgProperties.width;
 
-    pdf.addImage(data, 'PNG', 0, 0, pdfWidth, pdfHeight, '', 'FAST');
+    pdf.addImage(data, 'jpeg', 0, 0, pdfWidth, pdfHeight, '', 'FAST');
     pdf.save();
 };
 
 export const emailPdf = async (ref, sendEmailCallback) => {
     const element = ref.current;
     const canvas = await html2canvas(element, {
-        quality: 4,
-        scale: 5
+        quality: 5,
+        scale: 2
     });
     const data = canvas.toDataURL('image/png');
 


### PR DESCRIPTION
- generating larger pdfs with lots on them was crazy slow at the max quality settings. Dropping scale down a bit shows huge speed improvement without any real noticeable quality dropoff.
- this is really just a stop gap fix, as I've not been able to get pdfs that span more than one page to work with the current implementation (adding an image of the page contents to a pdf file). You also can't select/copy text from the pdfs this method generates - not ideal - so looking into other solutions today