### PR TITLE
Report exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ local-update.sh
 .vs
 
 *.tgz
+.idea*

--- a/src/Facade/Services/IPartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/IPartsReceivedReportFacadeService.cs
@@ -1,5 +1,7 @@
 ﻿namespace Linn.Purchasing.Facade.Services
 {
+    using System.IO;
+
     using Linn.Common.Facade;
     using Linn.Common.Reporting.Resources.ReportResultResources;
     using Linn.Purchasing.Resources.RequestResources;
@@ -7,6 +9,8 @@
     public interface IPartsReceivedReportFacadeService
     {
         public IResult<ReportReturnResource> GetReport(PartsReceivedReportRequestResource options);
+
+        public Stream GetReportCsv(PartsReceivedReportRequestResource options);
     }
 }
 

--- a/src/Facade/Services/IPartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/IPartsReceivedReportFacadeService.cs
@@ -1,6 +1,6 @@
 ﻿namespace Linn.Purchasing.Facade.Services
 {
-    using System.IO;
+    using System.Collections.Generic;
 
     using Linn.Common.Facade;
     using Linn.Common.Reporting.Resources.ReportResultResources;
@@ -10,7 +10,7 @@
     {
         public IResult<ReportReturnResource> GetReport(PartsReceivedReportRequestResource options);
 
-        public Stream GetReportCsv(PartsReceivedReportRequestResource options);
+        public IEnumerable<IEnumerable<string>> GetReportCsv(PartsReceivedReportRequestResource options);
     }
 }
 

--- a/src/Facade/Services/PartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/PartsReceivedReportFacadeService.cs
@@ -1,4 +1,6 @@
-﻿namespace Linn.Purchasing.Facade.Services
+﻿using System.Collections.Generic;
+
+namespace Linn.Purchasing.Facade.Services
 {
     using System.IO;
 
@@ -40,22 +42,15 @@
             return new SuccessResult<ReportReturnResource>(resource);
         }
 
-        public Stream GetReportCsv(PartsReceivedReportRequestResource options)
+        public IEnumerable<IEnumerable<string>> GetReportCsv(PartsReceivedReportRequestResource options)
         {
-            var result = this.domainService.GetReport(
+            return this.domainService.GetReport(
                 options.Jobref,
                 options.Supplier,
                 options.FromDate,
                 options.ToDate,
                 options.OrderBy,
-                options.IncludeNegativeValues);
-
-            var resource = result.ConvertToCsvList();
-            var stream = new MemoryStream();
-            var csvStreamWriter = new CsvStreamWriter(stream);
-            csvStreamWriter.WriteModel(resource);
-
-            return stream;
+                options.IncludeNegativeValues).ConvertToCsvList();
         }
     }
 }

--- a/src/Facade/Services/PartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/PartsReceivedReportFacadeService.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-
-namespace Linn.Purchasing.Facade.Services
+﻿namespace Linn.Purchasing.Facade.Services
 {
-    using System.IO;
+    using System.Collections.Generic;
 
     using Linn.Common.Facade;
     using Linn.Common.Reporting.Models;
@@ -10,7 +8,6 @@ namespace Linn.Purchasing.Facade.Services
     using Linn.Common.Reporting.Resources.ReportResultResources;
     using Linn.Purchasing.Domain.LinnApps.Reports;
     using Linn.Purchasing.Resources.RequestResources;
-    using Linn.Common.Serialization;
 
 
     public class PartsReceivedReportFacadeService : IPartsReceivedReportFacadeService

--- a/src/Facade/Services/PartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/PartsReceivedReportFacadeService.cs
@@ -1,10 +1,15 @@
 ﻿namespace Linn.Purchasing.Facade.Services
 {
+    using System.IO;
+
     using Linn.Common.Facade;
     using Linn.Common.Reporting.Models;
+    using Linn.Common.Reporting.Resources.Extensions;
     using Linn.Common.Reporting.Resources.ReportResultResources;
     using Linn.Purchasing.Domain.LinnApps.Reports;
     using Linn.Purchasing.Resources.RequestResources;
+    using Linn.Common.Serialization;
+
 
     public class PartsReceivedReportFacadeService : IPartsReceivedReportFacadeService
     {
@@ -33,6 +38,24 @@
                 null);
 
             return new SuccessResult<ReportReturnResource>(resource);
+        }
+
+        public Stream GetReportCsv(PartsReceivedReportRequestResource options)
+        {
+            var result = this.domainService.GetReport(
+                options.Jobref,
+                options.Supplier,
+                options.FromDate,
+                options.ToDate,
+                options.OrderBy,
+                options.IncludeNegativeValues);
+
+            var resource = result.ConvertToCsvList();
+            var stream = new MemoryStream();
+            var csvStreamWriter = new CsvStreamWriter(stream);
+            csvStreamWriter.WriteModel(resource);
+
+            return stream;
         }
     }
 }

--- a/src/Service.Host/.eslintrc.json
+++ b/src/Service.Host/.eslintrc.json
@@ -9,7 +9,6 @@
     },
     "rules": {
         "prettier/prettier": ["error"],
-        "linebreak-style": ["error", "windows"],
         "react/jsx-filename-extension": 0,
         "spaced-comment": "off",
         "react-hooks/rules-of-hooks": "error",

--- a/src/Service.Host/Program.cs
+++ b/src/Service.Host/Program.cs
@@ -13,7 +13,7 @@
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls("http://+:51699")
+                .UseUrls("http://+:5050")
                 .Build();
     }
 }

--- a/src/Service.Host/Program.cs
+++ b/src/Service.Host/Program.cs
@@ -13,7 +13,7 @@
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls("http://+:5050")
+                .UseUrls("http://+:51699")
                 .Build();
     }
 }

--- a/src/Service.Host/client/src/components/reports/PartsReceivedReport.js
+++ b/src/Service.Host/client/src/components/reports/PartsReceivedReport.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
+import queryString from 'query-string';
 import {
     Page,
     Title,
@@ -10,7 +11,8 @@ import {
     Loading,
     Dropdown,
     DatePicker,
-    ReportTable
+    ReportTable,
+    ExportButton
 } from '@linn-it/linn-form-components-library';
 import { useSelector, useDispatch } from 'react-redux';
 import history from '../../history';
@@ -188,16 +190,31 @@ function PartsReceivedReport() {
                 ) : (
                     <>
                         {reportData && (
-                            <Grid item xs={12}>
-                                <ReportTable
-                                    reportData={reportData}
-                                    title={reportData.title}
-                                    showTitle
-                                    showTotals
-                                    placeholderRows={4}
-                                    placeholderColumns={4}
-                                />
-                            </Grid>
+                            <>
+                                <Grid item xs={12}>
+                                    <ReportTable
+                                        reportData={reportData}
+                                        title={reportData.title}
+                                        showTitle
+                                        showTotals
+                                        placeholderRows={4}
+                                        placeholderColumns={4}
+                                    />
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <ExportButton
+                                        href={`${
+                                            config.appRoot
+                                        }/purchasing/reports/parts-received/export?${queryString.stringify(
+                                            {
+                                                ...options,
+                                                fromDate: options.fromDate.toISOString(),
+                                                toDate: options.toDate.toISOString()
+                                            }
+                                        )}`}
+                                    />
+                                </Grid>
+                            </>
                         )}
                     </>
                 )}

--- a/src/Service/Extensions/HttpResponseExtensions.cs
+++ b/src/Service/Extensions/HttpResponseExtensions.cs
@@ -1,12 +1,14 @@
 namespace Linn.Purchasing.Service.Extensions
 {
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
     using System.Collections.Generic;
     using System.IO;
     using System.Net.Mime;
+    using System.Threading.Tasks;
+    
     using Carter.Response;
     using Common.Serialization;
+    
+    using Microsoft.AspNetCore.Http;
     
     public static class HttpResponseExtensions
     {
@@ -22,7 +24,7 @@ namespace Linn.Purchasing.Service.Extensions
             return response.FromStream(
                 stream, 
                 "text/csv", 
-                new ContentDisposition {FileName = fileName});
+                new ContentDisposition { FileName = fileName });
         }
     }
 }

--- a/src/Service/Extensions/HttpResponseExtensions.cs
+++ b/src/Service/Extensions/HttpResponseExtensions.cs
@@ -18,6 +18,7 @@ namespace Linn.Purchasing.Service.Extensions
             var stream = new MemoryStream();
             var csvStreamWriter = new CsvStreamWriter(stream);
             csvStreamWriter.WriteModel(csvData);
+            stream.Position = 0;
             return response.FromStream(
                 stream, 
                 "text/csv", 

--- a/src/Service/Extensions/HttpResponseExtensions.cs
+++ b/src/Service/Extensions/HttpResponseExtensions.cs
@@ -1,0 +1,27 @@
+namespace Linn.Purchasing.Service.Extensions
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net.Mime;
+    using Carter.Response;
+    using Common.Serialization;
+    
+    public static class HttpResponseExtensions
+    {
+        public static Task FromCsv(
+            this HttpResponse response, 
+            IEnumerable<IEnumerable<string>> csvData,
+            string fileName)
+        {
+            var stream = new MemoryStream();
+            var csvStreamWriter = new CsvStreamWriter(stream);
+            csvStreamWriter.WriteModel(csvData);
+            return response.FromStream(
+                stream, 
+                "text/csv", 
+                new ContentDisposition {FileName = fileName});
+        }
+    }
+}

--- a/src/Service/Modules/Reports/PartsReceivedReportModule.cs
+++ b/src/Service/Modules/Reports/PartsReceivedReportModule.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Mime;
-
 namespace Linn.Purchasing.Service.Modules.Reports
 {
     using System.Threading.Tasks;
@@ -10,6 +9,8 @@ namespace Linn.Purchasing.Service.Modules.Reports
 
     using Linn.Purchasing.Facade.Services;
     using Linn.Purchasing.Resources.RequestResources;
+    
+    using Linn.Purchasing.Service.Extensions;
     using Linn.Purchasing.Service.Models;
 
     using Microsoft.AspNetCore.Http;
@@ -28,7 +29,7 @@ namespace Linn.Purchasing.Service.Modules.Reports
             this.reportFacadeService = reportFacadeService;
             this.Get("/purchasing/tqms-jobrefs", this.GetJobRefs);
             this.Get("/purchasing/reports/parts-received", this.GetReport);
-            this.Get("/purchasing/reports/parts-received", this.GetExport);
+            this.Get("/purchasing/reports/parts-received/export", this.GetExport);
         }
 
         private async Task GetJobRefs(HttpRequest request, HttpResponse response)
@@ -71,16 +72,9 @@ namespace Linn.Purchasing.Service.Modules.Reports
                     IncludeNegativeValues = req.Query.As<bool>("includeNegativeValues")
                 };
             
-            using var stream = this.reportFacadeService.GetReportCsv(options);
+            var csv = this.reportFacadeService.GetReportCsv(options);
 
-            var contentDisposition = new ContentDisposition
-            {
-                FileName =
-                    $"parts_received.csv"
-            };
-
-            stream.Position = 0;
-            await res.FromStream(stream, "text/csv", contentDisposition);
+            await res.FromCsv(csv, "parts_received.csv");
         }
     }
 }

--- a/src/Service/Modules/Reports/PartsReceivedReportModule.cs
+++ b/src/Service/Modules/Reports/PartsReceivedReportModule.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Mime;
-namespace Linn.Purchasing.Service.Modules.Reports
+﻿namespace Linn.Purchasing.Service.Modules.Reports
 {
     using System.Threading.Tasks;
 


### PR DESCRIPTION
- I didn't really like how we were doing csv responses (all of the csv -> stream business etc repeated across every report module / facade service) so I tried to move that stuff into a reusable method
- The Carter way of doing this sort of thing seems to be Extension methods to the Request/Response objects, so I stuck to that policy
- Let me know what y'all think and if we are happy I'll refactor all the csv exports to work this way
- could add this extension to Common.Carter if we so desire