### PR TITLE
fix param name

### DIFF
--- a/src/Service/Modules/PlCreditDebitNotesModule.cs
+++ b/src/Service/Modules/PlCreditDebitNotesModule.cs
@@ -44,10 +44,10 @@
         private async Task SearchNotes(
             HttpRequest req,
             HttpResponse res,
-            string search,
+            string searchTerm,
             IFacadeResourceFilterService<PlCreditDebitNote, int, PlCreditDebitNoteResource, PlCreditDebitNoteResource, PlCreditDebitNoteResource> service)
         {
-            var results = service.Search(search);
+            var results = service.Search(searchTerm);
 
             await res.Negotiate(results);
         }


### PR DESCRIPTION
I missed this typo that got introduced in the carter 6 switch