### PR TITLE
don't allow null vendor manager

### DIFF
--- a/src/Domain.LinnApps/Suppliers/SupplierService.cs
+++ b/src/Domain.LinnApps/Suppliers/SupplierService.cs
@@ -204,7 +204,7 @@
 
             candidate.VendorManager = candidate.VendorManager != null
                                     ? this.vendorManagerRepository.FindById(candidate.VendorManager.Id)
-                                    : null;
+                                    : this.vendorManagerRepository.FindById("A");
 
             candidate.AccountController = candidate.AccountController != null
                                     ? this.employeeRepository.FindById(candidate.AccountController.Id)

--- a/src/Service.Host/client/src/components/supplierUtility/tabs/WhoseTab.js
+++ b/src/Service.Host/client/src/components/supplierUtility/tabs/WhoseTab.js
@@ -92,7 +92,7 @@ function WhoseTab({
                 <Dropdown
                     items={vendorManagers.map(v => ({ id: v.vmId, displayText: v.name }))}
                     value={vendorManagerId}
-                    allowNoValue
+                    allowNoValue={false}
                     propertyName="vendorManagerId"
                     label="Vendor Manager"
                     onChange={handleFieldChange}

--- a/tests/Unit/Domain.LinnApps.Tests/SupplierServiceTests/WhenCreating.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/SupplierServiceTests/WhenCreating.cs
@@ -43,6 +43,7 @@
             this.SupplierPack.GetNextSupplierKey().Returns(1);
             this.EmployeeRepository.FindById(1).Returns(new Employee { Id = 1 });
             this.MockAddressRepository.FindById(1).Returns(new Address { FullAddress = new FullAddress { Id = 1 } });
+            this.VendorManagerRepository.FindById("A").Returns(new VendorManager { Id = "A", });
             this.privileges = new List<string> { "priv" };
             this.result = this.Sut.CreateSupplier(this.candidate, this.privileges);
         }
@@ -52,6 +53,7 @@
         {
             this.result.SupplierId.Should().Be(1);
             this.result.Name.Should().Be("SUPPLIER");
+            this.result.VendorManager.Id.Should().Be("A");
         }
     }
 }


### PR DESCRIPTION
- stops them accidentally not setting this to 'No Person Assigned' and causing some data lookup errors when using the supplier 