### PR TITLE
reqs - set edit status to view on save click, stops spam multi creation 

### DIFF
--- a/src/Service.Host/client/src/components/POReqs/POReqUtility.js
+++ b/src/Service.Host/client/src/components/POReqs/POReqUtility.js
@@ -1273,6 +1273,7 @@ function POReqUtility({ creating }) {
                                 saveDisabled={!canSave()}
                                 backClick={() => history.push('/purchasing')}
                                 saveClick={() => {
+                                    setEditStatus('view');
                                     clearErrors();
                                     setSnackbarMessage('Save successful');
                                     if (creating) {


### PR DESCRIPTION
could create multiple reqs if someone sat and spammed button or double clicked