### PR TITLE
don't include values for second delivery in report totals

### DIFF
--- a/src/Domain.LinnApps/Reports/PurchaseOrdersReportService.cs
+++ b/src/Domain.LinnApps/Reports/PurchaseOrdersReportService.cs
@@ -85,6 +85,8 @@
 
                 foreach (var orderDetail in order.Details.Where(d => d.Part.PartNumber == partNumber))
                 {
+                    var isFirstDelivery = true;
+
                     foreach (var delivery in orderDetail.PurchaseDeliveries)
                     {
                         if (!includeCancelled && (orderDetail.Cancelled == "Y" || delivery.Cancelled == "Y"))
@@ -92,7 +94,8 @@
                             continue;
                         }
 
-                        ExtractDetailsForPartReport(values, order, orderDetail, delivery, order.Currency.Code);
+                        ExtractDetailsForPartReport(values, order, orderDetail, delivery, order.Currency.Code, isFirstDelivery);
+                        isFirstDelivery = false;
                     }
                 }
             }
@@ -147,6 +150,7 @@
                         continue;
                     }
 
+                    var isFirstDelivery = true;
                     foreach (var delivery in orderDetail.PurchaseDeliveries)
                     {
                         if (!includeCancelled && (orderDetail.Cancelled == "Y" || delivery.Cancelled == "Y"))
@@ -171,7 +175,8 @@
 
                         var totalLedgerQty = ledgerQtys.Sum(x => x.TransType == "C" ? x.Qty : -x.Qty);
 
-                        ExtractSupplierReportDetails(values, orderDetail, delivery, totalLedgerQty, order.Currency.Code);
+                        ExtractSupplierReportDetails(values, orderDetail, delivery, totalLedgerQty, order.Currency.Code, isFirstDelivery);
+                        isFirstDelivery = false;
                     }
                 }
             }
@@ -386,7 +391,8 @@
             PurchaseOrderDetail orderDetail,
             PurchaseOrderDelivery delivery,
             decimal ledgerQty,
-            string currencyCode)
+            string currencyCode,
+            bool isFirstDelivery)
         {
             var currentRowId = $"{orderDetail.OrderNumber}/{orderDetail.Line}/{delivery.DeliverySeq}";
             values.Add(
@@ -414,14 +420,6 @@
             values.Add(
                 new CalculationValueModel
                     {
-                        RowId = currentRowId,
-                        ColumnId = "QtyOrd",
-                        TextDisplay = orderDetail.OurQty.HasValue ? orderDetail.OurQty.Value.ToString() : "0"
-                    });
-
-            values.Add(
-                new CalculationValueModel
-                    {
                         RowId = currentRowId, ColumnId = "QtyRec", TextDisplay = delivery.QtyNetReceived.ToString()
                     });
 
@@ -435,25 +433,35 @@
                 new CalculationValueModel
                     {
                         RowId = currentRowId,
-                        ColumnId = "BaseNetTotal",
-                        Value = orderDetail.BaseNetTotal,
-                        CurrencyCode = "GBP"
-                    });
-
-            values.Add(
-                new CalculationValueModel
-                    {
-                        RowId = currentRowId,
                         ColumnId = "Currency",
                         TextDisplay = currencyCode
                     });
-            values.Add(
-                new CalculationValueModel
-                    {
-                        RowId = currentRowId,
-                        ColumnId = "NetTotalCurrency",
-                        Value = orderDetail.NetTotalCurrency
-                });
+
+            if (isFirstDelivery)
+            {
+                values.Add(
+                    new CalculationValueModel
+                        {
+                            RowId = currentRowId,
+                            ColumnId = "QtyOrd",
+                            TextDisplay = orderDetail.OurQty.HasValue ? orderDetail.OurQty.Value.ToString() : "0"
+                        });
+
+                values.Add(
+                    new CalculationValueModel
+                        {
+                            RowId = currentRowId,
+                            ColumnId = "BaseNetTotal",
+                            Value = orderDetail.BaseNetTotal,
+                            CurrencyCode = "GBP"
+                        });
+
+                values.Add(
+                    new CalculationValueModel
+                        {
+                            RowId = currentRowId, ColumnId = "NetTotalCurrency", Value = orderDetail.NetTotalCurrency
+                        });
+            }
 
             values.Add(
                 new CalculationValueModel
@@ -489,7 +497,8 @@
             PurchaseOrder order,
             PurchaseOrderDetail orderDetail,
             PurchaseOrderDelivery delivery,
-            string currencyCode)
+            string currencyCode,
+            bool isFirstDelivery)
         {
             var currentRowId = $"{orderDetail.OrderNumber}/{orderDetail.Line}/{delivery.DeliverySeq}";
             values.Add(
@@ -517,24 +526,8 @@
             values.Add(
                 new CalculationValueModel
                     {
-                        RowId = currentRowId,
-                        ColumnId = "QtyOrd",
-                        Value = orderDetail.OurQty.HasValue ? orderDetail.OurQty.Value : 0
-                    });
-
-            values.Add(
-                new CalculationValueModel
-                    {
                         RowId = currentRowId, ColumnId = "QtyRec",
                         Value = delivery.QtyNetReceived ?? 0
-                    });
-
-            values.Add(
-                new CalculationValueModel
-                    {
-                        RowId = currentRowId,
-                        ColumnId = "BaseNetTotal",
-                        Value = orderDetail.BaseNetTotal
                     });
 
             values.Add(
@@ -545,13 +538,27 @@
                         TextDisplay = currencyCode
                     });
 
-            values.Add(
-                new CalculationValueModel
-                    {
-                        RowId = currentRowId,
-                        ColumnId = "NetTotalCurrency",
-                        Value = orderDetail.NetTotalCurrency
-                    });
+            if (isFirstDelivery)
+            {
+                values.Add(
+                    new CalculationValueModel
+                        {
+                            RowId = currentRowId,
+                            ColumnId = "QtyOrd",
+                            Value = orderDetail.OurQty.HasValue ? orderDetail.OurQty.Value : 0
+                        });
+                values.Add(
+                    new CalculationValueModel
+                        {
+                            RowId = currentRowId, ColumnId = "BaseNetTotal", Value = orderDetail.BaseNetTotal
+                        });
+
+                values.Add(
+                    new CalculationValueModel
+                        {
+                            RowId = currentRowId, ColumnId = "NetTotalCurrency", Value = orderDetail.NetTotalCurrency
+                        });
+            }
 
             values.Add(
                 new CalculationValueModel

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrdersReportServiceTests/WhenGettingOrdsByPartReport.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrdersReportServiceTests/WhenGettingOrdsByPartReport.cs
@@ -57,7 +57,7 @@
                                                                                        new PurchaseOrderDelivery
                                                                                            {
                                                                                                QtyNetReceived = 11,
-                                                                                               DeliverySeq = 1,
+                                                                                               DeliverySeq = 2,
                                                                                                OurDeliveryQty = 13,
                                                                                                NetTotalCurrency = 2m,
                                                                                                DateRequested =
@@ -68,7 +68,7 @@
                                                                                        new PurchaseOrderDelivery
                                                                                            {
                                                                                                QtyNetReceived = 11,
-                                                                                               DeliverySeq = 2,
+                                                                                               DeliverySeq = 3,
                                                                                                OurDeliveryQty = 13,
                                                                                                NetTotalCurrency = 2m,
                                                                                                DateRequested =
@@ -121,8 +121,8 @@
             this.results.ReportTitle.DisplayValue.Should().Be($"Purchase Orders By Part: {this.partNumber}");
             this.results.Rows.Count().Should().Be(2);
             var row = this.results.Rows.First();
-            row.RowId.Should().Be($"{this.orderNumber}/1/1");
-            this.results.GetGridTextValue(0, 0).Should().Be($"{this.orderNumber}/Line1/Delivery1");
+            row.RowId.Should().Be($"{this.orderNumber}/1/2");
+            this.results.GetGridTextValue(0, 0).Should().Be($"{this.orderNumber}/Line1/Delivery2");
             this.results.GetGridTextValue(0, 1).Should().Be(this.orderDate.ToString("dd-MMM-yyyy"));
             this.results.GetGridTextValue(0, 2).Should().Be($"{this.supplierId}: We sell stuff");
             this.results.GetGridValue(0, 3).Should().Be(3);
@@ -130,10 +130,29 @@
             this.results.GetGridValue(0, 5).Should().Be(14.12m);
             this.results.GetGridTextValue(0, 6).Should().Be("USD");
             this.results.GetGridValue(0, 7).Should().Be(17.23m);
-            this.results.GetGridTextValue(0, 8).Should().Be("1");
+            this.results.GetGridTextValue(0, 8).Should().Be("2");
             this.results.GetGridValue(0, 9).Should().Be(13);
-            this.results.GetGridTextValue(1, 0).Should().Be($"{this.orderNumber}/Line1/Delivery2");
-            this.results.GetGridTextValue(1, 8).Should().Be("2");
+            this.results.GetGridTextValue(1, 0).Should().Be($"{this.orderNumber}/Line1/Delivery3");
+            this.results.GetGridTextValue(1, 8).Should().Be("3");
+        }
+
+        [Test]
+        public void ShouldOnlyPopulateTotalsColumnsForFirstDelivery()
+        {
+            this.results.GetGridValue(0, 3).Should().Be(3);
+            this.results.GetGridValue(1, 3).Should().BeNull();
+
+            this.results.GetGridValue(0, 4).Should().Be(11);
+            this.results.GetGridValue(1, 4).Should().Be(11);
+
+            this.results.GetGridValue(0, 5).Should().Be(14.12m);
+            this.results.GetGridValue(1, 5).Should().BeNull();
+
+            this.results.GetGridTextValue(0, 6).Should().Be("USD");
+            this.results.GetGridTextValue(1, 6).Should().Be("USD");
+
+            this.results.GetGridValue(0, 7).Should().Be(17.23m);
+            this.results.GetGridValue(1, 7).Should().BeNull();
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrdersReportServiceTests/WhenGettingOrdsBySupplierReport.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrdersReportServiceTests/WhenGettingOrdsBySupplierReport.cs
@@ -148,5 +148,28 @@
             this.results.GetGridTextValue(1, 0).Should().Be($"{this.orderNumber}/Line1/Delivery2");
             this.results.GetGridTextValue(1, 9).Should().Be("2");
         }
+
+        [Test]
+        public void ShouldOnlyPopulateTotalsColumnsForFirstDelivery()
+        {
+            this.results.GetGridTextValue(0, 3).Should().Be("3");
+            this.results.GetGridTextValue(1, 3).Should().BeNull();
+
+            this.results.GetGridTextValue(0, 4).Should().Be("11");
+            this.results.GetGridTextValue(1, 4).Should().Be("11");
+
+            this.results.GetGridTextValue(0, 5).Should().Be("77");
+            this.results.GetGridTextValue(1, 5).Should().Be("77");
+
+            this.results.GetGridValue(0, 6).Should().Be(14.88m);
+            this.results.GetGridValue(1, 6).Should().BeNull();
+
+            this.results.GetGridTextValue(0, 7).Should().Be("USD");
+            this.results.GetGridTextValue(1, 7).Should().Be("USD");
+
+
+            this.results.GetGridValue(0, 8).Should().Be(17.34m);
+            this.results.GetGridValue(1, 8).Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
+ tests. Just not displaying the values that get totaled up after the first delivery. Funny wee bool instead of checking seq == 1 is me being paranoid that we delete the first delivery, not sure whether that's possible or not but don't think it's a big deal