### PR TITLE
Ack orders date input fix

### DIFF
--- a/src/Domain.LinnApps/Reports/ForecastWeekChangesReportService.cs
+++ b/src/Domain.LinnApps/Reports/ForecastWeekChangesReportService.cs
@@ -47,13 +47,13 @@
             foreach (var datum in data)
             {
                 var rowId = datum.LinnWeekNumber.ToString();
-
+                var endsOn = datum.LinnWeek.EndsOn;
                 values.Add(
                     new CalculationValueModel
                         {
                             RowId = rowId,
                             ColumnId = "EndsOn",
-                            TextDisplay = datum.LinnWeek.EndsOn.ToShortDateString()
+                            TextDisplay = $"{endsOn.Day}/{endsOn.Month}/{endsOn.Year}"
                         });
 
                 values.Add(

--- a/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
+++ b/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
@@ -16,6 +16,7 @@ import {
     SaveBackCancelButtons
 } from '@linn-it/linn-form-components-library';
 import Grid from '@mui/material/Grid';
+import moment from 'moment';
 import Dialog from '@mui/material/Dialog';
 import { makeStyles } from '@mui/styles';
 import Accordion from '@mui/material/Accordion';
@@ -39,7 +40,7 @@ import PurchaseOrderDeliveriesUtility from './PurchaseOrderDeliveriesUtility';
 function AcknowledgeOrdersUtility() {
     const dispatch = useDispatch();
     const { search } = useLocation();
-    const [lookUpExpanded, setLookUpExpanded] = useState(false);
+    const [lookUpExpanded, setLookUpExpanded] = useState(true);
     const [deliveriesDialogOpen, setDeliveriesDialogOpen] = useState(false);
     const [applyChangesDialogOpen, setApplyChangesDialogOpen] = useState(false);
 
@@ -236,7 +237,7 @@ function AcknowledgeOrdersUtility() {
                     orderNumber: r.orderNumber,
                     orderLine: r.orderLine,
                     deliverySequence: r.deliverySeq,
-                    dateAdvised: newValues.dateAdvised,
+                    dateAdvised: moment(newValues.dateAdvised).format('YYYY-MM-DDTHH:mm:ss'),
                     dateRequested: r.dateRequested,
                     qty: r.ourDeliveryQty,
                     reason: newValues.rescheduleReason,

--- a/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
+++ b/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
@@ -237,7 +237,9 @@ function AcknowledgeOrdersUtility() {
                     orderNumber: r.orderNumber,
                     orderLine: r.orderLine,
                     deliverySequence: r.deliverySeq,
-                    dateAdvised: moment(newValues.dateAdvised).format('YYYY-MM-DDTHH:mm:ss'),
+                    dateAdvised: newValues.dateAdvised
+                        ? moment(newValues.dateAdvised).format('YYYY-MM-DDTHH:mm:ss')
+                        : null,
                     dateRequested: r.dateRequested,
                     qty: r.ourDeliveryQty,
                     reason: newValues.rescheduleReason,
@@ -450,7 +452,12 @@ function AcknowledgeOrdersUtility() {
                                     <Button
                                         variant="outlined"
                                         disabled={!rows.some(r => r.selected)}
-                                        onClick={() => setApplyChangesDialogOpen(true)}
+                                        onClick={() => {
+                                            setNewValues({
+                                                rescheduleReason: 'ADVISED'
+                                            });
+                                            setApplyChangesDialogOpen(true);
+                                        }}
                                     >
                                         Apply Changes To Selected
                                     </Button>


### PR DESCRIPTION
- fixes an issue where seemingly sporadically some dates would end up being 11pm the day before the actual date when they got toISOString()'d
- presumably a tz issue as chopping of the timezone worked 
- I'll poke around and see if datepickers elswhere in the project have the same weird behaviour