### PR TITLE
set detail values in domain service

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -425,9 +425,9 @@
                                       * detail.OurUnitPriceCurrency.GetValueOrDefault();
 
             detail.DetailTotalCurrency = detail.NetTotalCurrency + detail.VatTotalCurrency;
-            detail.BaseNetTotal = detail.NetTotalCurrency/ (decimal)order.ExchangeRate;
+            detail.BaseNetTotal = Math.Round(detail.NetTotalCurrency / (decimal)order.ExchangeRate, 2);
             detail.BaseDetailTotal = 
-                detail.DetailTotalCurrency.GetValueOrDefault() / (decimal)order.ExchangeRate;
+                Math.Round(detail.DetailTotalCurrency.GetValueOrDefault() / (decimal)order.ExchangeRate, 2);
 
             NominalAccount nomAcc = null;
             if (part.StockControlled == "Y")

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -403,6 +403,11 @@
 
             order.ExchangeRate = this.currencyPack.GetExchangeRate("GBP", order.CurrencyCode);
 
+            if (order.ExchangeRate.GetValueOrDefault() == 0)
+            {
+                order.ExchangeRate = 1;
+            }
+
             var detail = order.Details.First();
             detail.OrderUnitPriceCurrency = detail.OurUnitPriceCurrency;
             detail.OrderQty = detail.OurQty;
@@ -415,6 +420,14 @@
             detail.OrderUnitOfMeasure = partSupplier != null ? partSupplier.UnitOfMeasure : string.Empty;
             detail.OurUnitOfMeasure = partSupplier != null ? partSupplier.UnitOfMeasure : string.Empty;
             detail.SuppliersDesignation = partSupplier != null ? partSupplier.SupplierDesignation : string.Empty;
+
+            detail.NetTotalCurrency = detail.OurQty.GetValueOrDefault() 
+                                      * detail.OurUnitPriceCurrency.GetValueOrDefault();
+
+            detail.DetailTotalCurrency = detail.NetTotalCurrency + detail.VatTotalCurrency;
+            detail.BaseNetTotal = detail.NetTotalCurrency/ (decimal)order.ExchangeRate;
+            detail.BaseDetailTotal = 
+                detail.DetailTotalCurrency.GetValueOrDefault() / (decimal)order.ExchangeRate;
 
             NominalAccount nomAcc = null;
             if (part.StockControlled == "Y")

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenFillingOutDetailsForNonSundryNonStockControlledPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenFillingOutDetailsForNonSundryNonStockControlledPart.cs
@@ -67,9 +67,9 @@
                     {
                         OrderAddress = new Address(),
                         InvoiceFullAddress = new FullAddress(),
-                        Currency = new Currency()
+                        Currency = new Currency { Code = "GBP" }
                     });
-
+            this.CurrencyPack.GetExchangeRate("GBP", "GBP").Returns(1);
             this.result = this.Sut.FillOutUnsavedOrder(this.args, 33087);
         }
 

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenFillingOutDetailsForStockControlledFinishedGoodsPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenFillingOutDetailsForStockControlledFinishedGoodsPart.cs
@@ -67,7 +67,7 @@
                     {
                         OrderAddress = new Address(),
                         InvoiceFullAddress = new FullAddress(),
-                        Currency = new Currency()
+                        Currency = new Currency { Code = "GB" }
                     });
             this.NominalAccountRepository
                 .FindBy(Arg.Any<Expression<Func<NominalAccount, bool>>>()).Returns(this.nominal);


### PR DESCRIPTION
 - hopefully fixes #400 (not the Requested Date part - thats another issue altogether)
 
 - Iain was calculating and setting these values in the purchaseOrderReducer which a) seems like a bad idea and b) only happens if you make a change to the quick-create form and dispatch some actions, hence wasn't working if you came from the MR and didnt change any fields
 
 - so I moved these calculations to the domain service 'FillOut...' method where they belong