### PR TITLE
Update delivery on detail change

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -952,11 +952,9 @@
             detail.RohsCompliant = "Y";
         }
 
-        private void UpdateDeliveries(
-            ICollection<PurchaseOrderDelivery> deliveries,
-            PurchaseOrderDetail purchaseOrder)
+        private void UpdateDeliveries(PurchaseOrderDetail purchaseOrder)
         {
-            foreach (var delivery in deliveries)
+            foreach (var delivery in purchaseOrder.PurchaseDeliveries)
             {
                 if (delivery.QuantityOutstanding > 0)
                 {
@@ -987,7 +985,7 @@
 
             this.UpdateOrderPostingsForDetail(current, updated);
 
-            this.UpdateDeliveries(current.PurchaseDeliveries, current);
+            this.UpdateDeliveries(current);
         }
 
         private void PerformDetailCalculations(PurchaseOrderDetail current, PurchaseOrderDetail updated, decimal exchangeRate, int supplierId, bool creating = false)

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -954,23 +954,22 @@
 
         private void UpdateDeliveries(
             ICollection<PurchaseOrderDelivery> deliveries,
-            ICollection<PurchaseOrderDelivery> updatedDeliveries)
+            PurchaseOrderDetail purchaseOrder)
         {
             foreach (var delivery in deliveries)
             {
                 if (delivery.QuantityOutstanding > 0)
                 {
-                    var updatedDelivery = updatedDeliveries.First(x => x.DeliverySeq == delivery.DeliverySeq);
-                    delivery.OrderUnitPriceCurrency = updatedDelivery.OrderUnitPriceCurrency;
-                    delivery.OurUnitPriceCurrency = updatedDelivery.OurUnitPriceCurrency;
-                    delivery.NetTotalCurrency = Math.Round((decimal)(updatedDelivery.OurDeliveryQty * updatedDelivery.OurUnitPriceCurrency));
-                    delivery.VatTotalCurrency = updatedDelivery.VatTotalCurrency;
-                    delivery.DeliveryTotalCurrency = updatedDelivery.DeliveryTotalCurrency;
-                    delivery.BaseOurUnitPrice = updatedDelivery.BaseOurUnitPrice;
-                    delivery.BaseOrderUnitPrice = updatedDelivery.BaseOrderUnitPrice;
-                    delivery.BaseVatTotal = updatedDelivery.BaseVatTotal;
-                    delivery.BaseDeliveryTotal = Math.Round((decimal)((updatedDelivery.OurDeliveryQty * updatedDelivery.BaseOurUnitPrice.GetValueOrDefault()) + updatedDelivery.BaseVatTotal), 2);
-                    delivery.BaseNetTotal = Math.Round((decimal)(updatedDelivery.OurDeliveryQty * updatedDelivery.BaseOurUnitPrice.GetValueOrDefault()), 2);
+                    delivery.OrderUnitPriceCurrency = purchaseOrder.OrderUnitPriceCurrency;
+                    delivery.OurUnitPriceCurrency = purchaseOrder.OurUnitPriceCurrency;
+                    delivery.NetTotalCurrency = purchaseOrder.NetTotalCurrency;
+                    delivery.VatTotalCurrency = purchaseOrder.VatTotalCurrency;
+                    delivery.DeliveryTotalCurrency = purchaseOrder.DetailTotalCurrency;
+                    delivery.BaseOurUnitPrice = purchaseOrder.BaseOurUnitPrice;
+                    delivery.BaseOrderUnitPrice = purchaseOrder.BaseOrderUnitPrice;
+                    delivery.BaseVatTotal = purchaseOrder.BaseVatTotal;
+                    delivery.BaseDeliveryTotal = Math.Round((decimal)((delivery.OurDeliveryQty * purchaseOrder.BaseOurUnitPrice.GetValueOrDefault()) + purchaseOrder.BaseVatTotal), 2);
+                    delivery.BaseNetTotal = purchaseOrder.BaseNetTotal;
                 }
             }
         }
@@ -988,7 +987,7 @@
 
             this.UpdateOrderPostingsForDetail(current, updated);
 
-            this.UpdateDeliveries(current.PurchaseDeliveries, updated.PurchaseDeliveries);
+            this.UpdateDeliveries(current.PurchaseDeliveries, current);
         }
 
         private void PerformDetailCalculations(PurchaseOrderDetail current, PurchaseOrderDetail updated, decimal exchangeRate, int supplierId, bool creating = false)

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -958,8 +958,20 @@
         {
             foreach (var delivery in deliveries)
             {
-                var updatedDelivery = updatedDeliveries.First(x => x.DeliverySeq == delivery.DeliverySeq);
-                delivery.DateRequested = updatedDelivery.DateRequested;
+                if (delivery.QuantityOutstanding > 0)
+                {
+                    var updatedDelivery = updatedDeliveries.First(x => x.DeliverySeq == delivery.DeliverySeq);
+                    delivery.OrderUnitPriceCurrency = updatedDelivery.OrderUnitPriceCurrency;
+                    delivery.OurUnitPriceCurrency = updatedDelivery.OurUnitPriceCurrency;
+                    delivery.NetTotalCurrency = Math.Round((decimal)(updatedDelivery.OurDeliveryQty * updatedDelivery.OurUnitPriceCurrency));
+                    delivery.VatTotalCurrency = updatedDelivery.VatTotalCurrency;
+                    delivery.DeliveryTotalCurrency = updatedDelivery.DeliveryTotalCurrency;
+                    delivery.BaseOurUnitPrice = updatedDelivery.BaseOurUnitPrice;
+                    delivery.BaseOrderUnitPrice = updatedDelivery.BaseOrderUnitPrice;
+                    delivery.BaseVatTotal = updatedDelivery.BaseVatTotal;
+                    delivery.BaseDeliveryTotal = Math.Round((decimal)((updatedDelivery.OurDeliveryQty * updatedDelivery.BaseOurUnitPrice.GetValueOrDefault()) + updatedDelivery.BaseVatTotal), 2);
+                    delivery.BaseNetTotal = Math.Round((decimal)(updatedDelivery.OurDeliveryQty * updatedDelivery.BaseOurUnitPrice.GetValueOrDefault()), 2);
+                }
             }
         }
 

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
@@ -1,6 +1,5 @@
 ﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.PurchaseOrderServiceTests
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
@@ -1,5 +1,6 @@
 ﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.PurchaseOrderServiceTests
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -59,24 +60,24 @@
                                                                            DateAdvised = 1.February(2022),
                                                                            DateRequested = 23.January(2022),
                                                                            DeliverySeq = 1,
-                                                                           NetTotalCurrency = 120m,
-                                                                           BaseNetTotal = 100m,
+                                                                           NetTotalCurrency = 0m,
+                                                                           BaseNetTotal = 0m,
                                                                            OrderDeliveryQty = 1,
                                                                            OrderLine = 1,
                                                                            OrderNumber = this.orderNumber,
-                                                                           OurDeliveryQty = 1,
+                                                                           OurDeliveryQty = 2,
                                                                            QtyNetReceived = 0,
                                                                            QuantityOutstanding = 1,
                                                                            CallOffDate = null,
-                                                                           BaseOurUnitPrice = 100m,
+                                                                           BaseOurUnitPrice = 0m,
                                                                            SupplierConfirmationComment = "supplied",
-                                                                           OurUnitPriceCurrency = 120m,
-                                                                           OrderUnitPriceCurrency = 120m,
+                                                                           OurUnitPriceCurrency = 0m,
+                                                                           OrderUnitPriceCurrency = 0m,
                                                                            BaseOrderUnitPrice = 100m,
                                                                            VatTotalCurrency = 0m,
                                                                            BaseVatTotal = 0m,
-                                                                           DeliveryTotalCurrency = 120m,
-                                                                           BaseDeliveryTotal = 100m,
+                                                                           DeliveryTotalCurrency =  0m,
+                                                                           BaseDeliveryTotal = 0m,
                                                                            RescheduleReason = string.Empty,
                                                                            AvailableAtSupplier = "N"
                                                                        }
@@ -190,8 +191,8 @@
                                                                            OrderDeliveryQty = 1,
                                                                            OrderLine = 1,
                                                                            OrderNumber = this.orderNumber,
-                                                                           OurDeliveryQty = 1,
-                                                                           QtyNetReceived = 0,
+                                                                           OurDeliveryQty = 2,
+                                                                           QtyNetReceived = 1,
                                                                            QuantityOutstanding = 1,
                                                                            CallOffDate = null,
                                                                            BaseOurUnitPrice = 100m,
@@ -199,8 +200,8 @@
                                                                            OurUnitPriceCurrency = 120m,
                                                                            OrderUnitPriceCurrency = 120m,
                                                                            BaseOrderUnitPrice = 100m,
-                                                                           VatTotalCurrency = 0m,
-                                                                           BaseVatTotal = 0m,
+                                                                           VatTotalCurrency = 60m,
+                                                                           BaseVatTotal = 60m,
                                                                            DeliveryTotalCurrency = 120m,
                                                                            BaseDeliveryTotal = 100m,
                                                                            RescheduleReason = string.Empty,
@@ -353,10 +354,6 @@
             firstDetail.SuppliersDesignation.Should().Be("updated suppliers designation");
 
             firstDetail.OrderPosting.NominalAccountId.Should().Be(911);
-
-            var delivery = firstDetail.PurchaseDeliveries.First();
-
-            delivery.DateRequested.Should().Be(29.January(2022));
         }
 
         [Test]
@@ -394,6 +391,36 @@
             // net total + vat total
             this.miniOrder.OrderTotal.Should().Be(19862.33m);
             this.miniOrder.BaseOrderTotal.Should().Be(24827.91m);
+        }
+
+        [Test]
+        public void ShouldUpdateDeliveryTotalFields()
+        {
+            this.current.OrderNumber.Should().Be(600179);
+            this.current.Remarks.Should().Be("updated remarks");
+
+            var firstDetail = this.current.Details.First();
+
+            var delivery = firstDetail.PurchaseDeliveries.First();
+
+            // order unit price currency, our unit price currency, our delivery qty
+            delivery.OrderUnitPriceCurrency.Should().Be(120m);
+            delivery.OurUnitPriceCurrency.Should().Be(120m);
+            delivery.OurDeliveryQty.Should().Be(2);
+
+            //our delivery qty * our unit currency = net total currency
+            delivery.NetTotalCurrency.Should().Be(240m);
+            delivery.VatTotalCurrency.Should().Be(60);
+            delivery.DeliveryTotalCurrency.Should().Be(120m);
+
+            // base our unit price, base order unit price
+            delivery.BaseOurUnitPrice.Should().Be(100m);
+            delivery.BaseOrderUnitPrice.Should().Be(100m);
+
+            //(our delivery qty * base our unit price) + base vat total  = base delivery total
+            delivery.BaseNetTotal.Should().Be(200m);
+            delivery.BaseVatTotal.Should().Be(60m);
+            delivery.BaseDeliveryTotal.Should().Be(260m);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
@@ -1,6 +1,5 @@
 ﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.PurchaseOrderServiceTests
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -73,7 +72,7 @@
                                                                            SupplierConfirmationComment = "supplied",
                                                                            OurUnitPriceCurrency = 0m,
                                                                            OrderUnitPriceCurrency = 0m,
-                                                                           BaseOrderUnitPrice = 100m,
+                                                                           BaseOrderUnitPrice = 0m,
                                                                            VatTotalCurrency = 0m,
                                                                            BaseVatTotal = 0m,
                                                                            DeliveryTotalCurrency =  0m,
@@ -404,23 +403,23 @@
             var delivery = firstDetail.PurchaseDeliveries.First();
 
             // order unit price currency, our unit price currency, our delivery qty
-            delivery.OrderUnitPriceCurrency.Should().Be(120m);
-            delivery.OurUnitPriceCurrency.Should().Be(120m);
+            delivery.OrderUnitPriceCurrency.Should().Be(400.44m);
+            delivery.OurUnitPriceCurrency.Should().Be(200.22m);
             delivery.OurDeliveryQty.Should().Be(2);
 
             //our delivery qty * our unit currency = net total currency
-            delivery.NetTotalCurrency.Should().Be(240m);
-            delivery.VatTotalCurrency.Should().Be(60);
-            delivery.DeliveryTotalCurrency.Should().Be(120m);
+            delivery.NetTotalCurrency.Should().Be(19821.78m);
+            delivery.VatTotalCurrency.Should().Be(40.55m);
+            delivery.DeliveryTotalCurrency.Should().Be(19862.33m);
 
             // base our unit price, base order unit price
-            delivery.BaseOurUnitPrice.Should().Be(100m);
-            delivery.BaseOrderUnitPrice.Should().Be(100m);
+            delivery.BaseOurUnitPrice.Should().Be(250.28m);
+            delivery.BaseOrderUnitPrice.Should().Be(500.55m);
 
             //(our delivery qty * base our unit price) + base vat total  = base delivery total
-            delivery.BaseNetTotal.Should().Be(200m);
-            delivery.BaseVatTotal.Should().Be(60m);
-            delivery.BaseDeliveryTotal.Should().Be(260m);
+            delivery.BaseNetTotal.Should().Be(24777.23m);
+            delivery.BaseVatTotal.Should().Be(50.69m);
+            delivery.BaseDeliveryTotal.Should().Be(551.25m);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
@@ -1,5 +1,6 @@
 ﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.PurchaseOrderServiceTests
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderOverrideValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderOverrideValueQtyFields.cs
@@ -64,19 +64,19 @@
                                                                            OrderDeliveryQty = 1,
                                                                            OrderLine = 1,
                                                                            OrderNumber = this.orderNumber,
-                                                                           OurDeliveryQty = 1,
+                                                                           OurDeliveryQty = 5,
                                                                            QtyNetReceived = 0,
                                                                            QuantityOutstanding = 1,
                                                                            CallOffDate = null,
-                                                                           BaseOurUnitPrice = 100m,
+                                                                           BaseOurUnitPrice = 0m,
                                                                            SupplierConfirmationComment = "supplied",
-                                                                           OurUnitPriceCurrency = 120m,
-                                                                           OrderUnitPriceCurrency = 120m,
-                                                                           BaseOrderUnitPrice = 100m,
+                                                                           OurUnitPriceCurrency = 0m,
+                                                                           OrderUnitPriceCurrency = 0m,
+                                                                           BaseOrderUnitPrice = 0m,
                                                                            VatTotalCurrency = 0m,
                                                                            BaseVatTotal = 0m,
-                                                                           DeliveryTotalCurrency = 120m,
-                                                                           BaseDeliveryTotal = 100m,
+                                                                           DeliveryTotalCurrency = 0m,
+                                                                           BaseDeliveryTotal = 0m,
                                                                            RescheduleReason = string.Empty,
                                                                            AvailableAtSupplier = "N"
                                                                        }
@@ -190,8 +190,8 @@
                                                                            OrderDeliveryQty = 1,
                                                                            OrderLine = 1,
                                                                            OrderNumber = this.orderNumber,
-                                                                           OurDeliveryQty = 1,
-                                                                           QtyNetReceived = 0,
+                                                                           OurDeliveryQty = 5,
+                                                                           QtyNetReceived = 1,
                                                                            QuantityOutstanding = 1,
                                                                            CallOffDate = null,
                                                                            BaseOurUnitPrice = 100m,
@@ -199,8 +199,8 @@
                                                                            OurUnitPriceCurrency = 120m,
                                                                            OrderUnitPriceCurrency = 120m,
                                                                            BaseOrderUnitPrice = 100m,
-                                                                           VatTotalCurrency = 0m,
-                                                                           BaseVatTotal = 0m,
+                                                                           VatTotalCurrency = 60m,
+                                                                           BaseVatTotal = 60m,
                                                                            DeliveryTotalCurrency = 120m,
                                                                            BaseDeliveryTotal = 100m,
                                                                            RescheduleReason = string.Empty,
@@ -351,10 +351,6 @@
             firstDetail.SuppliersDesignation.Should().Be("updated suppliers designation");
 
             firstDetail.OrderPosting.NominalAccountId.Should().Be(911);
-
-            var delivery = firstDetail.PurchaseDeliveries.First();
-
-            delivery.DateRequested.Should().Be(29.January(2022));
         }
 
         [Test]
@@ -391,6 +387,36 @@
             // net total + vat total
             this.miniOrder.OrderTotal.Should().Be(19862.33m);
             this.miniOrder.BaseOrderTotal.Should().Be(24827.91m);
+        }
+
+        [Test]
+        public void ShouldUpdateDeliveryTotalFields()
+        {
+            this.current.OrderNumber.Should().Be(600179);
+            this.current.Remarks.Should().Be("updated remarks");
+
+            var firstDetail = this.current.Details.First();
+
+            var delivery = firstDetail.PurchaseDeliveries.First();
+
+            // order unit price currency, our unit price currency, our delivery qty
+            delivery.OrderUnitPriceCurrency.Should().Be(120m);
+            delivery.OurUnitPriceCurrency.Should().Be(120m);
+            delivery.OurDeliveryQty.Should().Be(5);
+
+            //Our Delivery Qty * Our Unit Currency = Net Total Currency
+            delivery.NetTotalCurrency.Should().Be(600m);
+            delivery.VatTotalCurrency.Should().Be(60);
+            delivery.DeliveryTotalCurrency.Should().Be(120m);
+
+            // base our unit price, base order unit price
+            delivery.BaseOurUnitPrice.Should().Be(100m);
+            delivery.BaseOrderUnitPrice.Should().Be(100m);
+
+            //(our delivery qty * base our unit price) + base vat total  = base delivery total
+            delivery.BaseNetTotal.Should().Be(500m);
+            delivery.BaseVatTotal.Should().Be(60m);
+            delivery.BaseDeliveryTotal.Should().Be(560m);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderOverrideValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderOverrideValueQtyFields.cs
@@ -400,23 +400,23 @@
             var delivery = firstDetail.PurchaseDeliveries.First();
 
             // order unit price currency, our unit price currency, our delivery qty
-            delivery.OrderUnitPriceCurrency.Should().Be(120m);
-            delivery.OurUnitPriceCurrency.Should().Be(120m);
+            delivery.OrderUnitPriceCurrency.Should().Be(200m);
+            delivery.OurUnitPriceCurrency.Should().Be(200.22m);
             delivery.OurDeliveryQty.Should().Be(5);
 
-            //Our Delivery Qty * Our Unit Currency = Net Total Currency
-            delivery.NetTotalCurrency.Should().Be(600m);
-            delivery.VatTotalCurrency.Should().Be(60);
-            delivery.DeliveryTotalCurrency.Should().Be(120m);
+            //our delivery qty * our unit currency = net total currency
+            delivery.NetTotalCurrency.Should().Be(19821.78m);
+            delivery.VatTotalCurrency.Should().Be(40.55m);
+            delivery.DeliveryTotalCurrency.Should().Be(19862.33m);
 
             // base our unit price, base order unit price
-            delivery.BaseOurUnitPrice.Should().Be(100m);
-            delivery.BaseOrderUnitPrice.Should().Be(100m);
+            delivery.BaseOurUnitPrice.Should().Be(250.28m);
+            delivery.BaseOrderUnitPrice.Should().Be(250m);
 
             //(our delivery qty * base our unit price) + base vat total  = base delivery total
-            delivery.BaseNetTotal.Should().Be(500m);
-            delivery.BaseVatTotal.Should().Be(60m);
-            delivery.BaseDeliveryTotal.Should().Be(560m);
+            delivery.BaseNetTotal.Should().Be(24777.23m);
+            delivery.BaseVatTotal.Should().Be(50.69m);
+            delivery.BaseDeliveryTotal.Should().Be(1302.09m);
         }
     }
 }


### PR DESCRIPTION
C# changes. Question is now do we remove recalculateDetailFields from the purchaseorder reducer? Going to submit that as a separate PR if consensus is yes 