### PR TITLE
FOC - allow 0 for key fields

### DIFF
--- a/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
@@ -273,15 +273,9 @@ function PurchaseOrderUtility({ creating }) {
             d =>
                 d.partNumber &&
                 d.ourQty &&
-                d.ourUnitPriceCurrency &&
-                d.orderUnitPriceCurrency &&
                 d.ourUnitOfMeasure &&
                 d.orderPosting?.nominalAccount?.department?.departmentCode &&
-                d.orderPosting?.nominalAccount?.nominal?.nominalCode &&
-                d.netTotalCurrency &&
-                d.detailTotalCurrency &&
-                d.baseNetTotal &&
-                d.baseDetailTotal
+                d.orderPosting?.nominalAccount?.nominal?.nominalCode
         ) &&
         order.currency.code &&
         order.deliveryAddress?.addressId;


### PR DESCRIPTION
Current form checks that ourUnitPriceCurrency, orderUnitPriceCurrency, netTotalCurrency, detailTotalCurrency, baseNetTotal and baseDetailTotal all have values before enabling the save button. A FOC order requires all of these fields to equal 0 and therefore the condition isn't satisfied.

An alternative to the current check would be to check if each var is equal to or above zero as opposed to removing. Let me know thoughts. 

React test to for main form to follow that will test this in a new PR.