### PR TITLE
Support tickets

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -368,10 +368,15 @@
         {
             if (order.Supplier?.SupplierId == null)
             {
-                throw new DomainException("Cannot create a purchase order without a supplier");
+                throw new PurchaseOrderException("Cannot create a purchase order without a supplier");
             }
 
             var supplier = this.supplierRepository.FindById(order.Supplier.SupplierId);
+
+            if (supplier.DateClosed != null)
+            {
+                throw new PurchaseOrderException("Supplier is closed!");
+            }
 
             order.Supplier = supplier;
             order.OrderAddress = supplier.OrderAddress;

--- a/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
+++ b/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
@@ -530,10 +530,6 @@ function AcknowledgeOrdersUtility() {
                                         variant="outlined"
                                         disabled={!rows.some(r => r.selected)}
                                         onClick={() => {
-                                            // setNewValues(nv => ({
-                                            //     ...nv,
-                                            //     rescheduleReason: 'ADVISED'
-                                            // }));
                                             setApplyChangesDialogOpen(true);
                                         }}
                                     >

--- a/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
+++ b/src/Service.Host/client/src/components/AcknowledgeOrdersUtility.js
@@ -240,6 +240,14 @@ function AcknowledgeOrdersUtility() {
                 selected.includes(r.id) ? { ...r, selected: true } : { ...r, selected: false }
             )
         );
+        if (selected.length) {
+            setNewValues(nv => ({
+                ...nv,
+                dateAdvised:
+                    moment(rows.find(x => x.id === selected[selected.length - 1])?.dateAdvised) ||
+                    moment()
+            }));
+        }
     };
 
     const uploadLoading = useSelector(state =>
@@ -522,10 +530,10 @@ function AcknowledgeOrdersUtility() {
                                         variant="outlined"
                                         disabled={!rows.some(r => r.selected)}
                                         onClick={() => {
-                                            setNewValues({
-                                                rescheduleReason: 'ADVISED',
-                                                dateAdvised: moment()
-                                            });
+                                            // setNewValues(nv => ({
+                                            //     ...nv,
+                                            //     rescheduleReason: 'ADVISED'
+                                            // }));
                                             setApplyChangesDialogOpen(true);
                                         }}
                                     >

--- a/src/Service.Host/client/src/components/ChangeRequests/CreateChangeRequest.js
+++ b/src/Service.Host/client/src/components/ChangeRequests/CreateChangeRequest.js
@@ -5,7 +5,6 @@ import {
     collectionSelectorHelpers,
     Dropdown,
     InputField,
-    itemSelectorHelpers,
     userSelectors
 } from '@linn-it/linn-form-components-library';
 import Grid from '@mui/material/Grid';

--- a/src/Service.Host/client/src/components/PurchaseOrders/CreatePurchaseOrderUt.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/CreatePurchaseOrderUt.js
@@ -466,7 +466,7 @@ function CreatePurchaseOrderUt() {
                                     label="Supplier"
                                     modal
                                     propertyName="supplierId"
-                                    items={suppliersSearchResults}
+                                    items={suppliersSearchResults.filter(s => !s.dateClosed)}
                                     value={order.supplier?.id}
                                     loading={suppliersSearchLoading}
                                     fetchItems={searchSuppliers}

--- a/src/Service.Host/client/src/components/PurchaseOrders/CreatePurchaseOrderUt.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/CreatePurchaseOrderUt.js
@@ -13,11 +13,11 @@ import {
     Page,
     collectionSelectorHelpers,
     Dropdown,
-    Typeahead,
     InputField,
     itemSelectorHelpers,
     Loading,
-    utilities
+    utilities,
+    Search
 } from '@linn-it/linn-form-components-library';
 import queryString from 'query-string';
 import LinearProgress from '@mui/material/LinearProgress';
@@ -48,6 +48,10 @@ function CreatePurchaseOrderUt() {
         queryString.parse(search);
 
     const [stockControlledPart, setStockControlled] = useState(null);
+
+    const [supplierSearchTerm, setSupplierSearchTerm] = useState();
+
+    const [partSearchTerm, setPartSearchTerm] = useState();
 
     useEffect(() => {
         reduxDispatch(purchaseOrderActions.fetchState());
@@ -374,15 +378,24 @@ function CreatePurchaseOrderUt() {
                             </>
                         )}
                         <Grid item xs={11}>
-                            <Typeahead
-                                label="Part"
-                                title="Search for a part"
-                                onSelect={newPart => {
+                            <Search
+                                propertyName="searchTerm"
+                                label="Part Number"
+                                resultsInModal
+                                resultLimit={100}
+                                value={partSearchTerm}
+                                handleValueChange={(_, newVal) => setPartSearchTerm(newVal)}
+                                search={() => reduxDispatch(partsActions.search(partSearchTerm))}
+                                searchResults={partsSearchResults}
+                                loading={partsSearchLoading}
+                                priorityFunction="closestMatchesFirst"
+                                onResultSelect={newPart => {
                                     handleDetailFieldChange(
                                         'partNumber',
                                         newPart.id,
                                         order.details[0]
                                     );
+                                    setPartSearchTerm(newPart.partNumber);
                                     if (newPart.stockControlled === 'Y') {
                                         setStockControlled(true);
                                         reduxDispatch(
@@ -395,19 +408,7 @@ function CreatePurchaseOrderUt() {
                                         setStockControlled(false);
                                     }
                                 }}
-                                items={partsSearchResults}
-                                loading={partsSearchLoading}
-                                fetchItems={searchTerm =>
-                                    reduxDispatch(partsActions.search(searchTerm))
-                                }
-                                clearSearch={() => reduxDispatch(partsActions.clearSearch)}
-                                value={detail.partNumber}
-                                modal
-                                links={false}
-                                debounce={1000}
-                                minimumSearchTermLength={4}
-                                disabled={!allowedToCreate() || isCreditOrReturn()}
-                                placeholder="click to set part"
+                                clearSearch={() => {}}
                             />
                         </Grid>
                         <Grid item xs={1}>
@@ -444,7 +445,7 @@ function CreatePurchaseOrderUt() {
                                                 s.supplierRanking === 1 ? '(P)' : ''
                                             }`
                                         }))}
-                                    onChange={(propertyName, selected) => {
+                                    onChange={(_, selected) => {
                                         handleSupplierChange({ id: selected });
                                         dispatch({
                                             payload: {
@@ -462,21 +463,23 @@ function CreatePurchaseOrderUt() {
                             </Grid>
                         ) : (
                             <Grid item xs={4}>
-                                <Typeahead
+                                <Search
+                                    value={supplierSearchTerm}
+                                    handleValueChange={(_, newVal) => setSupplierSearchTerm(newVal)}
+                                    search={searchSuppliers}
+                                    searchResults={suppliersSearchResults.filter(
+                                        s => !s.dateClosed
+                                    )}
                                     label="Supplier"
-                                    modal
+                                    resultsInModal
                                     propertyName="supplierId"
                                     items={suppliersSearchResults.filter(s => !s.dateClosed)}
-                                    value={order.supplier?.id}
                                     loading={suppliersSearchLoading}
-                                    fetchItems={searchSuppliers}
-                                    links={false}
-                                    on
-                                    text
                                     clearSearch={() => {}}
                                     placeholder="Search Suppliers"
-                                    onSelect={newValue => {
+                                    onResultSelect={newValue => {
                                         handleSupplierChange(newValue);
+                                        setSupplierSearchTerm(newValue.name);
                                     }}
                                     minimumSearchTermLength={3}
                                     fullWidth

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenFillingOutOrderAndSupplierIsClosed.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenFillingOutOrderAndSupplierIsClosed.cs
@@ -1,0 +1,72 @@
+﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.PurchaseOrderServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    using FluentAssertions;
+
+    using Linn.Purchasing.Domain.LinnApps.Exceptions;
+    using Linn.Purchasing.Domain.LinnApps.Parts;
+    using Linn.Purchasing.Domain.LinnApps.PartSuppliers;
+    using Linn.Purchasing.Domain.LinnApps.PurchaseOrders;
+    using Linn.Purchasing.Domain.LinnApps.Suppliers;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenFillingOutOrderAndSupplierIsClosed : ContextBase
+    {
+        private PurchaseOrder args;
+
+        private Part part;
+
+        private Action action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.part = new Part
+                            {
+                                OurUnitOfMeasure = "ONES",
+                                PartNumber = "SUNDRY"
+                            };
+            this.PartQueryRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
+                .Returns(this.part);
+            this.args = new PurchaseOrder
+                            {
+                                Supplier = new Supplier { SupplierId = 1 },
+                                DeliveryAddress = new LinnDeliveryAddress(),
+                                Details =
+                                    new List<PurchaseOrderDetail>
+                                        {
+                                            new PurchaseOrderDetail
+                                                {
+                                                    Line = 1,
+                                                    Part = this.part
+                                                }
+                                        }
+                            };
+            this.SupplierRepository
+                .FindById(
+                    this.args.Supplier.SupplierId).Returns(
+                    new Supplier
+                        {
+                            OrderAddress = new Address(),
+                            InvoiceFullAddress = new FullAddress(),
+                            Currency = new Currency(),
+                            DateClosed = DateTime.UnixEpoch
+                    });
+
+            this.action = () => this.Sut.FillOutUnsavedOrder(this.args, 33087);
+        }
+
+        [Test]
+        public void ShouldThrowException()
+        {
+            this.action.Should().Throw<PurchaseOrderException>().WithMessage("Supplier is closed!");
+        }
+    }
+}


### PR DESCRIPTION
- default to most recently selected date advised when acknowledging orders (as opposed to todays date)
- don't allow raising orders for closed suppliers
- replace typeaheads for new search components in purchase order quick-create screen - Let me know if you think thats a bad idea