### PR TITLE
convert string ids to ints before running query

### DIFF
--- a/src/Domain.LinnApps/Boms/BomReportsService.cs
+++ b/src/Domain.LinnApps/Boms/BomReportsService.cs
@@ -149,7 +149,8 @@
 
             var ids = treeNodes.Select(x => x.Id).ToList();
 
-            var details = this.bomCostReportDetails.FilterBy(x => ids.Contains(x.DetailId.ToString())).ToList();
+            var details = this.bomCostReportDetails.FilterBy(x => ids.Select(
+                i => string.IsNullOrEmpty(i) ? 0 : int.Parse(i)).Contains(x.DetailId)).ToList();
 
             details = details.OrderBy(d => ids.IndexOf(d.DetailId.ToString())).ToList();
 


### PR DESCRIPTION
- weird bug where trying to compare strings to ints in an oracle query causes the usual massive/exponential loss in performance, basically made the report never return data