### PR TITLE
Wildsearch

### DIFF
--- a/src/Domain.LinnApps/Boms/IChangeRequestService.cs
+++ b/src/Domain.LinnApps/Boms/IChangeRequestService.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq.Expressions;
 
     using Linn.Purchasing.Domain.LinnApps.Parts;
 
@@ -18,5 +19,7 @@
         ChangeRequest MakeLive(int documentNumber, int appliedById, IEnumerable<int> selectedBomChangeIds, IEnumerable<int> selectedPcasChangeIds, IEnumerable<string> privileges = null);
 
         ChangeRequest PhaseInChanges(int documentNumber, int? linnWeekNumber, DateTime? linnWeekStartDate, IEnumerable<int> selectedBomChangeIds, IEnumerable<string> privileges = null);
+
+        Expression<Func<ChangeRequest, bool>> SearchExpression(string searchTerm, bool? outstanding, int? lastMonths);
     }
 }

--- a/src/Facade/Services/ChangeRequestFacadeService.cs
+++ b/src/Facade/Services/ChangeRequestFacadeService.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
-    using System.Text.RegularExpressions;
 
     using Linn.Common.Domain.Exceptions;
     using Linn.Common.Facade;
@@ -205,20 +204,17 @@
             var changeRequests = new List<ChangeRequest>();
 
             var fromDate = (lastMonths == null)
-                               ? new DateTime(2020, 1, 1)
+                               ? DateTime.Now.AddMonths(-120)
                                : DateTime.Now.AddMonths(-1 * (int)lastMonths);
-            var inclLive = ((outstanding == false) ? "LIVE" : "JUSTOUTSTANDING");
+            var inclLive = (outstanding == false) ? "LIVE" : "JUSTOUTSTANDING";
 
-            var newPartNumber = searchTerm.Trim().ToUpper().Replace('%', '*');
+            var newPartNumber = searchTerm.Trim().ToUpper();
             var partSearch = newPartNumber.Split('*');
 
             // this big if is just because Linq/EF/Oracle doesn't do a LIKE
             // supports IC*, *3, *LEWIS*, PCAS*L1R1 but not multiple * e.g. PCAS */L1*
             if (string.IsNullOrEmpty(newPartNumber))
             {
-                var a = this.repository.FilterBy(
-                    r => (r.ChangeState == "PROPOS" || r.ChangeState == "ACCEPT" || r.ChangeState == inclLive)
-                         && r.ChangeState != "CANCEL" && r.DateEntered >= fromDate);
                 changeRequests = this.repository.FilterBy(r => (r.ChangeState == "PROPOS" || r.ChangeState == "ACCEPT" || r.ChangeState == inclLive) && r.ChangeState != "CANCEL" && r.DateEntered >= fromDate).ToList();
             }
             else if (!newPartNumber.Contains("*"))
@@ -307,7 +303,5 @@
         {
             throw new NotImplementedException();
         }
-
-
     }
 }

--- a/src/Facade/Services/ChangeRequestFacadeService.cs
+++ b/src/Facade/Services/ChangeRequestFacadeService.cs
@@ -289,15 +289,7 @@
 
         protected override Expression<Func<ChangeRequest, bool>> SearchExpression(string searchTerm)
         {
-            // check if contains wildcard
-            if (searchTerm.Contains("*"))
-            {
-                var pattern = Regex.Escape(searchTerm).Replace("\\*", ".*?");
-                var regex = new Regex(pattern, RegexOptions.IgnoreCase);
-                return cr => regex.IsMatch(cr.NewPartNumber) && cr.ChangeState != "LIVE" && cr.ChangeState != "CANCEL";
-            }
-
-            return cr => searchTerm.Trim().ToUpper().Equals(cr.NewPartNumber) 
+           return cr => searchTerm.Trim().ToUpper().Equals(cr.NewPartNumber) 
                          && cr.ChangeState != "LIVE" && cr.ChangeState != "CANCEL";
         }
 

--- a/src/Facade/Services/IChangeRequestFacadeService.cs
+++ b/src/Facade/Services/IChangeRequestFacadeService.cs
@@ -39,5 +39,8 @@
 
         IResult<IEnumerable<ChangeRequestResource>> GetChangeRequestsRelevantToBoard(
             string bomName, IEnumerable<string> privileges = null);
+
+        IResult<IEnumerable<ChangeRequestResource>> SearchChangeRequests(
+            string searchTerm, bool? outstanding, int? lastMonths, IEnumerable<string> privileges = null);
     }
 }

--- a/src/Service/Modules/ChangeRequestModule.cs
+++ b/src/Service/Modules/ChangeRequestModule.cs
@@ -39,7 +39,9 @@
             IChangeRequestFacadeService facadeService,
             string searchTerm,
             bool? includeAllForBom,
-            bool? includeForBoard)
+            bool? includeForBoard,
+            bool? outstanding,
+            int? lastMonths)
         {
             if (string.IsNullOrEmpty(searchTerm))
             {
@@ -56,7 +58,7 @@
             }
             else
             {
-                await res.Negotiate(facadeService.Search(searchTerm));
+                await res.Negotiate(facadeService.SearchChangeRequests(searchTerm, outstanding, lastMonths));
             }
         }
 

--- a/tests/Integration/Integration.Tests/ChangeRequestModuleTests/WhenGettingBoardChangeRequests.cs
+++ b/tests/Integration/Integration.Tests/ChangeRequestModuleTests/WhenGettingBoardChangeRequests.cs
@@ -9,7 +9,6 @@
     using FluentAssertions;
 
     using Linn.Purchasing.Domain.LinnApps.Boms;
-    using Linn.Purchasing.Domain.LinnApps.Boms.Models;
     using Linn.Purchasing.Integration.Tests.Extensions;
     using Linn.Purchasing.Resources;
 
@@ -21,18 +20,19 @@
         [SetUp]
         public void SetUp()
         {
-            this.Repository.FilterBy(Arg.Any<Expression<Func<ChangeRequest, bool>>>())
+            this.Repository.FilterBy(Arg.Any<Expression<Func<ChangeRequest,bool>>>())
                 .Returns(new List<ChangeRequest>
                              {
                                  new ChangeRequest
                                      {
                                          NewPartNumber = "SK HUB",
-                                         DateEntered = DateTime.Today
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
                                      }
                              }.AsQueryable());
 
             this.Response = this.Client.Get(
-                "/purchasing/change-requests?searchTerm=SK HUB&includeAllForBoard=True",
+                "/purchasing/change-requests?searchTerm=SK HUB&includeForBoard=True",
                 with => { with.Accept("application/json"); }).Result;
         }
 

--- a/tests/Integration/Integration.Tests/ChangeRequestModuleTests/WhenSearchingChangeRequests.cs
+++ b/tests/Integration/Integration.Tests/ChangeRequestModuleTests/WhenSearchingChangeRequests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Linq.Expressions;
     using System.Net;
 
     using FluentAssertions;
@@ -20,18 +19,25 @@
         [SetUp]
         public void SetUp()
         {
-            this.Repository.FilterBy(Arg.Any<Expression<Func<ChangeRequest, bool>>>())
+            this.Repository.FindAll()
                 .Returns(new List<ChangeRequest>
                              {
                                  new ChangeRequest
                                      {
                                          NewPartNumber = "SK HUB",
-                                         DateEntered = DateTime.Today
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
+                                     },
+                                 new ChangeRequest
+                                     {
+                                         NewPartNumber = "TURNTABLE",
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
                                      }
                              }.AsQueryable());
 
             this.Response = this.Client.Get(
-                "/purchasing/change-requests?searchTerm=SK HUB",
+                "/purchasing/change-requests?searchTerm=*HUB*",
                 with => { with.Accept("application/json"); }).Result;
         }
 
@@ -51,7 +57,7 @@
         [Test]
         public void ShouldCallRepository()
         {
-            this.Repository.Received().FilterBy(Arg.Any<Expression<Func<ChangeRequest, bool>>>());
+            this.Repository.Received().FindAll();
         }
 
         [Test]

--- a/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/WhenSearchingChangeRequests.cs
+++ b/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/WhenSearchingChangeRequests.cs
@@ -1,0 +1,63 @@
+﻿namespace Linn.Purchasing.Facade.Tests.ChangeRequestFacadeServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Linn.Common.Facade;
+    using Linn.Purchasing.Domain.LinnApps.Boms;
+    using Linn.Purchasing.Resources;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenSearchingChangeRequests : ContextBase
+    {
+        private IResult<IEnumerable<ChangeRequestResource>> result;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            this.Repository.FindAll()
+                .Returns(new List<ChangeRequest>
+                             {
+                                 new ChangeRequest
+                                     {
+                                         DocumentNumber = 1,
+                                         NewPartNumber = "TEST1",
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
+                                     },
+                                 new ChangeRequest
+                                     {
+                                         DocumentNumber = 2,
+                                         NewPartNumber = "TOAST2",
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
+                                     }
+                             }.AsQueryable());
+
+            this.result = this.Sut.SearchChangeRequests("TEST*", true, null);
+        }
+
+        [Test]
+        public void ShouldReturnSuccessRequest()
+        {
+            this.result.Should().BeOfType<SuccessResult<IEnumerable<ChangeRequestResource>>>();
+        }
+
+        [Test]
+        public void ShouldReturnOneMatchingChangeRequest()
+        {
+            var resources = ((SuccessResult<IEnumerable<ChangeRequestResource>>)this.result).Data;
+            resources.Count().Should().Be(1);
+            var request = resources.First();
+            request.DocumentNumber.Should().Be(1);
+            request.NewPartNumber.Should().Be("TEST1");
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/WhenSearchingChangeRequestsWithNoSearchTerm.cs
+++ b/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/WhenSearchingChangeRequestsWithNoSearchTerm.cs
@@ -1,0 +1,57 @@
+﻿namespace Linn.Purchasing.Facade.Tests.ChangeRequestFacadeServiceTests
+{
+    using Linn.Common.Facade;
+    using Linn.Purchasing.Domain.LinnApps.Boms;
+    using Linn.Purchasing.Resources;
+    using NSubstitute;
+    using NUnit.Framework;
+    using System.Collections.Generic;
+    using System;
+    using System.Linq;
+
+    using FluentAssertions;
+
+    public class WhenSearchingChangeRequestsWithNoSearchTerm : ContextBase
+    {
+        private IResult<IEnumerable<ChangeRequestResource>> result;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            this.Repository.FindAll()
+                .Returns(new List<ChangeRequest>
+                             {
+                                 new ChangeRequest
+                                     {
+                                         DocumentNumber = 1,
+                                         NewPartNumber = "TEST1",
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
+                                     },
+                                 new ChangeRequest
+                                     {
+                                         DocumentNumber = 2,
+                                         NewPartNumber = "TOAST2",
+                                         DateEntered = DateTime.Today,
+                                         ChangeState = "ACCEPT"
+                                     }
+                             }.AsQueryable());
+
+            this.result = this.Sut.SearchChangeRequests("", true, null);
+        }
+
+        [Test]
+        public void ShouldReturnSuccessRequest()
+        {
+            this.result.Should().BeOfType<SuccessResult<IEnumerable<ChangeRequestResource>>>();
+        }
+
+        [Test]
+        public void ShouldReturnAllMatchingChangeRequests()
+        {
+            var resources = ((SuccessResult<IEnumerable<ChangeRequestResource>>)this.result).Data;
+            resources.Count().Should().Be(2);
+        }
+    }
+}

--- a/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/WhenUpdatingChangeRequest.cs
+++ b/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/WhenUpdatingChangeRequest.cs
@@ -1,15 +1,12 @@
 ﻿namespace Linn.Purchasing.Facade.Tests.ChangeRequestFacadeServiceTests
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq.Expressions;
 
     using FluentAssertions;
 
     using Linn.Common.Facade;
     using Linn.Purchasing.Domain.LinnApps;
     using Linn.Purchasing.Domain.LinnApps.Boms;
-    using Linn.Purchasing.Domain.LinnApps.Parts;
     using Linn.Purchasing.Resources;
 
     using NSubstitute;


### PR DESCRIPTION
Ability to search change requests using wildcards either * or % work
The following work
- TESTASS3
- TESTASS*
- *3
- *LEWIS*

Would have liked a LINQ like that worked with EF but Regex not supported and hence clunky if to cope with these conditions and can't cope with something like PCAS */L1* but that's an edge case

also added a filter with ability to show recent live changes but will need Jacki to see if these values are useful or not