### PR TITLE
Even more bom ut

### DIFF
--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -250,6 +250,7 @@
             }
 
             node.DeleteChangeDocumentNumber = null;
+            node.ChangeState = "LIVE"; // todo - check this is right - add to test if so
             this.bomDetailRepository.FindById(int.Parse(node.Id)).DeleteChangeId = null;
         }
 
@@ -277,7 +278,6 @@
 
             replacedDetail.DeleteChangeId = change.ChangeId;
             replacedDetail.DeleteReplaceSeq = seq + 1;
-            replacedDetail.ChangeState = change.ChangeState;
         }
 
         private Bom GetOrCreateBom(string name)

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -124,10 +124,10 @@
 
                 var isDeletion = child.ToDelete.GetValueOrDefault();
 
-                var isDeletionUndo = new[] { "ACCEPT", "PROPOS" }.Contains(child.ChangeState)
+                var isDeletionUndo = !child.IsReplaced && new[] { "ACCEPT", "PROPOS" }.Contains(child.ChangeState)
                                             && child.DeleteChangeDocumentNumber.HasValue;
 
-                var isExistingNodeUpdate = bom.Details != null && string.IsNullOrEmpty(child.ReplacedBy)
+                var isExistingNode = bom.Details != null && string.IsNullOrEmpty(child.ReplacedBy)
                                                     && bom.Details.Select(x => x.DetailId.ToString())
                                                         .Contains(child.Id);
 
@@ -147,9 +147,9 @@
                     {
                         this.AddNode(child, change, ref replacementSeq);
                     }
-                    else if (isExistingNodeUpdate)
+                    else if (isExistingNode)
                     {
-                        this.UpdateNode(child, change);
+                        this.MaybeUpdateNode(child, change);
                     }
 
                     if (isReplacement)
@@ -189,7 +189,7 @@
             });
         }
 
-        private void UpdateNode(BomTreeNode node, BomChange change)
+        private void MaybeUpdateNode(BomTreeNode node, BomChange change)
         {
             var detail = this.bomDetailRepository.FindById(int.Parse(node.Id));
             if (detail.Qty != node.Qty || detail.GenerateRequirement != node.Requirement)

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -12,7 +12,6 @@
     using Linn.Purchasing.Domain.LinnApps.ExternalServices;
     using Linn.Purchasing.Domain.LinnApps.Parts;
 
-
     public class BomChangeService : IBomChangeService
     {
         private readonly IDatabaseService databaseService;
@@ -111,14 +110,16 @@
 
         private void ProcessBomChange(BomTreeNode current, BomChange change, Bom bom)
         {
-            var detailsOnChange = this.bomDetailRepository
-                .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);
-
-            var replacementSeq = !detailsOnChange.Any() ? 0
-                                     : detailsOnChange.Max(d => d.AddReplaceSeq.GetValueOrDefault());
-
             foreach (var child in current.Children)
             {
+                int replacementSeq = 0;
+
+                var detailsOnChange = this.bomDetailRepository
+                    .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);
+
+                replacementSeq = detailsOnChange == null || !detailsOnChange.Any() ? 0
+                                         : detailsOnChange.Max(d => d.AddReplaceSeq.GetValueOrDefault());
+
                 var isAddition = bom.Details
                                  == null || bom.Details.Count == 0
                                          || bom.Details.All(d => d.DetailId.ToString() != child.Id);

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -112,12 +112,10 @@
         {
             foreach (var child in current.Children)
             {
-                int replacementSeq = 0;
-
                 var detailsOnChange = this.bomDetailRepository
                     .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);
 
-                replacementSeq = detailsOnChange == null || !detailsOnChange.Any() ? 0
+                var replacementSeq = detailsOnChange == null || !detailsOnChange.Any() ? 0
                                          : detailsOnChange.Max(d => d.AddReplaceSeq.GetValueOrDefault());
 
                 var isAddition = bom.Details

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -113,6 +113,7 @@
         {
             var detailsOnChange = this.bomDetailRepository
                 .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);
+
             var replacementSeq = !detailsOnChange.Any() ? 0
                                      : detailsOnChange.Max(d => d.AddReplaceSeq.GetValueOrDefault());
 
@@ -285,11 +286,6 @@
             {
                 throw new InvalidBomChangeException(
                     $"{node.Name} was added by the current change request - no need to replace it - just edit it directly.");
-            }
-
-            if (replacement.Name == change.BomName)
-            {
-                throw new InvalidBomChangeException($"Can't add {replacement.Name} to it's own BOM!");
             }
 
             if (replacedDetail.PcasLine == "Y")

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -11,6 +11,8 @@
     using Linn.Purchasing.Domain.LinnApps.Exceptions;
     using Linn.Purchasing.Domain.LinnApps.ExternalServices;
     using Linn.Purchasing.Domain.LinnApps.Parts;
+    using Linn.Purchasing.Domain.LinnApps.PurchaseOrders;
+    using Org.BouncyCastle.Asn1.Ocsp;
 
     public class BomChangeService : IBomChangeService
     {
@@ -42,7 +44,7 @@
             this.bomPack = bomPack;
         }
 
-        public BomTreeNode CreateBomChanges(BomTreeNode tree, int changeRequestNumber, int enteredBy)
+        public BomTreeNode ProcessTreeUpdate(BomTreeNode tree, int changeRequestNumber, int enteredBy)
         {
             // traversing the updated tree...
             var q = new Queue<BomTreeNode>();
@@ -58,7 +60,7 @@
                     if (current.HasChanged.GetValueOrDefault() && current.Children != null)
                     {
                         var bomLookup = this.bomRepository.FindBy(x => x.BomName == current.Name);
-
+                        
                         // create a bom if required
                         var bom = bomLookup ?? new Bom
                                       {
@@ -68,240 +70,47 @@
                                           Depth = 1,
                                           CommonBom = "N"
                                       };
-
-                        if (bomLookup == null)
-                        {
-                            this.bomRepository.Add(bom);
-                            bom.Part.BomId = bom.BomId;
-                        }
-
-                        // obtain a bom_change to make incoming changes against
-                        // check if there's an open one for this bom
-                        var change = this.bomChangeRepository.FindBy(
-                            x => x.DocumentNumber == changeRequestNumber 
-                                 && new[] { "ACCEPT", "PROPOS" }.Contains(x.ChangeState)
-                                 && x.BomName == current.Name);
-
-                        // create a new bom change if not
-                        if (change == null)
-                        {
-                            var id = this.databaseService.GetIdSequence("CHG_SEQ");
-                            change = new BomChange
-                                         {
-                                             BomId = bom.BomId,
-                                             ChangeId = id,
-                                             BomName = current.Name,
-                                             DocumentType = "CRF", // for now
-                                             DocumentNumber = changeRequestNumber,
-                                             PartNumber = current.Name,
-                                             DateEntered = DateTime.Today,
-                                             EnteredById = enteredBy,
-                                             ChangeState = "PROPOS",
-                                             Comments = "BOM_UT",
-                                             PcasChange = "N"
-                                         };
-                            this.bomChangeRepository.Add(change);
-                        }
-
-                        var detailsOnChange = this.bomDetailRepository
-                            .FilterBy(x => x.BomId == bom.BomId && x.AddChangeId == change.ChangeId);
                         
-                        var replacementSeq = !detailsOnChange.Any() ? 0 
-                                                 : detailsOnChange.Max(d => d.AddReplaceSeq.GetValueOrDefault());
-
-                        var children = current.Children.ToList();
-                        foreach (var child in children.ToList())
-                        {
-                            var part = this.partRepository.FindBy(x => x.PartNumber == child.Name);
-
-                            if (part == null)
+                            if (bomLookup == null)
                             {
-                                throw new ItemNotFoundException($"Invalid Part Number: {child.Name} on Assembly: {current.Name}");
+                                this.bomRepository.Add(bom);
+                                bom.Part.BomId = bom.BomId;
+                            }
+                        
+                            // obtain a bom_change to make incoming changes against
+                            // check if there's an open one for this bom
+                            var change = this.bomChangeRepository.FindBy(
+                                x => x.DocumentNumber == changeRequestNumber 
+                                     && new[] { "ACCEPT", "PROPOS" }.Contains(x.ChangeState)
+                                     && x.BomName == current.Name);
+                        
+                            // create a new bom change if not
+                            if (change == null)
+                            {
+                                var id = this.databaseService.GetIdSequence("CHG_SEQ");
+                                change = new BomChange
+                                             {
+                                                 BomId = bom.BomId,
+                                                 ChangeId = id,
+                                                 BomName = current.Name,
+                                                 DocumentType = "CRF", // for now
+                                                 DocumentNumber = changeRequestNumber,
+                                                 PartNumber = current.Name,
+                                                 DateEntered = DateTime.Today,
+                                                 EnteredById = enteredBy,
+                                                 ChangeState = "PROPOS",
+                                                 Comments = "BOM_UT",
+                                                 PcasChange = "N"
+                                             };
+                                this.bomChangeRepository.Add(change);
                             }
 
-                            if (new[] { "ACCEPT", "PROPOS" }.Contains(child.ChangeState) 
-                                && child.DeleteChangeDocumentNumber.HasValue)
-                            {
-                                // case: undo a deletion
-                                child.DeleteChangeDocumentNumber = null;
-                                this.bomDetailRepository.FindById(int.Parse(child.Id)).DeleteChangeId = null;
-                                continue;
-                            }
-                            else if (child.ToDelete.GetValueOrDefault())
-                            {
-                                // case: deletion
-                                var detail = this.bomDetailRepository.FindById(int.Parse(child.Id));
-
-                                if (detail.DeleteChangeId.HasValue
-                                    && detail.DeleteChange?.DocumentNumber != changeRequestNumber)
-                                {
-                                    throw new InvalidBomChangeException(
-                                        $"{child.Name} is already marked for deletion by another change request"
-                                        + $" ({detail.DeleteChange?.DocumentNumber})");
-                                }
-
-                                if (detail.PcasLine == "Y")
-                                {
-                                    throw new InvalidBomChangeException($"{child.Name} is a PCAS line - cannot delete here.");
-                                }
-
-                                // case: deleting a detail added by this change request
-                                if (detail.AddChange.DocumentNumber == changeRequestNumber)
-                                {
-                                    // just delete the PROPOS'd record
-                                    this.bomDetailRepository.Remove(detail);
-
-                                    // and remove it from the tree
-                                    children.Remove(child);
-
-                                    if (detail.AddReplaceSeq.HasValue)
-                                    {
-                                        // case: deleting a replacement record = undoing a replacement
-                                        // tidy up the other side of the replacement to undelete the detail
-                                        var replacedDetail = this.bomDetailRepository.FindBy(
-                                            x => x.DeleteChangeId == change.ChangeId
-                                                 && x.DeleteReplaceSeq == detail.AddReplaceSeq);
-                                        replacedDetail.DeleteReplaceSeq = null;
-                                        replacedDetail.DeleteChangeId = null;
-                                        var nodeToUpdate = current.Children.FirstOrDefault(
-                                            x => x.DeleteChangeDocumentNumber == changeRequestNumber);
-
-                                        nodeToUpdate.DeleteChangeDocumentNumber = null;
-                                        nodeToUpdate.DeleteReplaceSeq = null;
-                                    }
-                                }
-                                else
-                                {
-                                    detail.DeleteChangeId = change.ChangeId;
-                                    child.DeleteChangeDocumentNumber = change.DocumentNumber;
-                                }
-                            }
-                            else
-                            {
-                                if (bom.Details == null || bom.Details.Count == 0 || bom.Details.All(d => d.DetailId.ToString() != child.Id))
-                                {
-                                    // case: adding a new detail
-                                    if (part.DatePurchPhasedOut
-                                        .HasValue)
-                                    {
-                                        throw new InvalidBomChangeException(
-                                            $"Can't add {child.Name} to {child.ParentName} - part has been phased out by purchasing");
-                                    }
-
-                                    if (string.IsNullOrEmpty(part.DecrementRule))
-                                    {
-                                        throw new InvalidBomChangeException(
-                                            $"Can't add {child.Name} to {child.ParentName} - part has no decrement rule!");
-                                    }
-
-                                    if (string.IsNullOrEmpty(part.BomType))
-                                    {
-                                        throw new InvalidBomChangeException(
-                                            $"Can't add {child.Name} to {child.ParentName} - part has no BOM Type!");
-                                    }
-
-                                    child.ChangeState = "PROPOS";
-
-                                    // stop bom loops
-                                    // todo: this check will only stop us adding a part to its own bom in its first level of children
-                                    // but we can still add a part to its own bom one level deeper, for example, and still create a loop
-                                    // do we need to think of a way to stop this happening? Does the oracle form do anything more?
-                                    if (child.Name == current.Name)
-                                    {
-                                        throw new InvalidBomChangeException($"Can't add {child.Name} to it's own BOM!");
-                                    }
-
-                                    var id = this.databaseService.GetIdSequence("BOMDET_SEQ");
-
-                                    this.bomDetailRepository.Add(new BomDetail
-                                    {
-                                        DetailId = id,
-                                        BomId = bom.BomId,
-                                        PartNumber = child.Name,
-                                        Qty = child.Qty,
-                                        GenerateRequirement = child.Requirement,
-                                        ChangeState = "PROPOS",
-                                        AddChangeId = change.ChangeId,
-                                        AddReplaceSeq = string.IsNullOrEmpty(child.ReplacementFor)
-                                                                             ? null : replacementSeq + 1,
-                                        DeleteChangeId = null,
-                                        DeleteReplaceSeq = null,
-                                        PcasLine = "N"
-                                    });
-                                    child.AddChangeDocumentNumber = change.DocumentNumber;
-
-                                    var replacement =
-                                        current.Children.FirstOrDefault(c => c.ReplacementFor == child.Id);
-                                    
-                                    if (replacement != null)
-                                    {
-                                        replacement.ReplacementFor = id.ToString();
-                                    }
-
-                                    child.Id = id.ToString();
-                                } 
-                                else if (bom.Details != null
-                                              && string.IsNullOrEmpty(child.ReplacedBy)
-                                              && bom.Details.Select(x => x.DetailId.ToString()).Contains(child.Id))
-                                {
-                                    // case: updating fields of existing component on this bom
-                                    // can only do this if part was added by current crf
-                                    var toUpdate = this.bomDetailRepository.FindById(int.Parse(child.Id));
-
-                                    if (toUpdate.Qty != child.Qty || toUpdate.GenerateRequirement != child.Requirement)
-                                    {
-                                        if (toUpdate.AddChangeId != change.ChangeId)
-                                        {
-                                            throw new InvalidBomChangeException(
-                                                "Can't directly update details added by a different CRF - Replace them instead!");
-                                        }
-
-                                        toUpdate.Qty = child.Qty;
-                                        toUpdate.GenerateRequirement = child.Requirement;
-                                    }
-                                }
-
-                                if (!string.IsNullOrEmpty(child.ReplacedBy))
-                                {
-                                    // case: replacing a detail on this bom with a new detail
-                                    var replacement = current.Children.FirstOrDefault(c => c.ReplacementFor == child.Id);
-                                    if (replacement == null)
-                                    {
-                                        throw new InvalidBomChangeException(
-                                            $"{child.Name} is marked for replacement but no replacement part is specified");
-                                    }
-                                    
-                                    var replacedDetail = this.bomDetailRepository.FindById(int.Parse(child.Id));
-
-                                    if (child.AddChangeDocumentNumber == changeRequestNumber)
-                                    {
-                                        throw new InvalidBomChangeException(
-                                            $"{child.Name} was added by the current change request - no need to replace it - just edit it directly.");
-                                    }
-
-                                    // stop bom loops
-                                    // todo: same consideration as above in the adding case
-                                    if (replacement.Name == current.Name)
-                                    {
-                                        throw new InvalidBomChangeException($"Can't add {replacement.Name} to it's own BOM!");
-                                    }
-
-                                    if (replacedDetail.PcasLine == "Y")
-                                    {
-                                        throw new InvalidBomChangeException(
-                                            $"{child.Name} is a PCAS line - cannot replace here.");
-                                    }
-
-                                    child.DeleteReplaceSeq = replacementSeq + 1;
-                                    replacedDetail.DeleteChangeId = change.ChangeId;
-                                    replacedDetail.DeleteReplaceSeq = replacementSeq + 1;
-                                    replacedDetail.ChangeState = "PROPOS";
-                                }
-                            }
-                        }
-
-                        current.Children = children;
-                        current.HasChanged = false;
+                            this.ProcessBomChangeForSubAssembly(current, change);
+                        
+                            var children = current.Children.ToList();
+                            
+                            current.Children = children;
+                            current.HasChanged = false;
                     }
 
                     if (current.Children != null)
@@ -347,6 +156,204 @@
         {
             var change = this.GetOrCreateBomChange(bomName, crfNumber, changedBy);
             this.bomPack.ExplodeSubAssembly(change.BomId, change.ChangeId, change.ChangeState, subAssembly);
+        }
+
+        private void ProcessBomChangeForSubAssembly(BomTreeNode current, BomChange change)
+        {
+            var bom = this.bomRepository.FindBy(x => x.BomName == current.Name);
+
+            // initialise replacement seq to be the max replacement seq currently on this change
+            var detailsOnChange = this.bomDetailRepository
+                .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);
+            var replacementSeq = !detailsOnChange.Any() ? 0
+                                     : detailsOnChange.Max(d => d.AddReplaceSeq.GetValueOrDefault());
+
+            var children = current.Children.ToList();
+            foreach (var child in children.ToList())
+            {
+                var isAddition = bom.Details
+                                 == null || bom.Details.Count == 0
+                                         || bom.Details.All(d => d.DetailId.ToString() != child.Id);
+
+                var isDeletion = child.ToDelete.GetValueOrDefault();
+
+                var isDeletionUndo = new[] { "ACCEPT", "PROPOS" }.Contains(child.ChangeState)
+                                            && child.DeleteChangeDocumentNumber.HasValue;
+
+                var isExistingNodeUpdate = bom.Details != null && string.IsNullOrEmpty(child.ReplacedBy)
+                                                    && bom.Details.Select(x => x.DetailId.ToString())
+                                                        .Contains(child.Id);
+
+                var isReplacement = !string.IsNullOrEmpty(child.ReplacedBy);
+
+                if (isDeletionUndo)
+                {
+                    this.UndoNodeDeletion(child);
+                }
+                else if (isDeletion)
+                {
+                    this.DeleteNode(child, change);
+                }
+                else
+                {
+                    if (isAddition)
+                    {
+                        this.AddNode(child, change, replacementSeq);
+                    }
+                    else if (isExistingNodeUpdate)
+                    {
+                        this.UpdateNode(child, change);
+                    }
+
+                    if (isReplacement)
+                    {
+                        var replacement = current.Children.FirstOrDefault(c => c.ReplacementFor == child.Id);
+                        this.DoNodeReplacement(child, replacement, change, replacementSeq);
+                    }
+                }
+            }
+        }
+
+        private void AddNode(BomTreeNode node, BomChange change, int? replacementSeq)
+        {
+            var part = this.partRepository.FindBy(p => p.PartNumber == node.Name);
+
+            if (part == null)
+            {
+                throw new ItemNotFoundException($"Invalid Part Number: {node.Name} on Assembly: BOM");
+            }
+
+            if (part.DatePurchPhasedOut.HasValue)
+            {
+                throw new InvalidBomChangeException(
+                    $"Can't add {node.Name} to {node.ParentName} - part has been phased out by purchasing");
+            }
+
+            if (string.IsNullOrEmpty(part.DecrementRule))
+            {
+                throw new InvalidBomChangeException(
+                    $"Can't add {node.Name} to {node.ParentName} - part has no decrement rule!");
+            }
+
+            if (string.IsNullOrEmpty(part.BomType))
+            {
+                throw new InvalidBomChangeException(
+                    $"Can't add {node.Name} to {node.ParentName} - part has no BOM Type!");
+            }
+
+            node.ChangeState = "PROPOS";
+
+            if (node.Name == change.BomName)
+            {
+                throw new InvalidBomChangeException($"Can't add {node.Name} to it's own BOM!");
+            }
+
+            var id = this.databaseService.GetIdSequence("BOMDET_SEQ");
+
+            this.bomDetailRepository.Add(new BomDetail
+            {
+                DetailId = id,
+                BomId = change.BomId,
+                PartNumber = node.Name,
+                Qty = node.Qty,
+                GenerateRequirement = node.Requirement,
+                ChangeState = "PROPOS",
+                AddChangeId = change.ChangeId,
+                AddReplaceSeq = string.IsNullOrEmpty(node.ReplacementFor)
+                                                     ? null : replacementSeq + 1,
+                DeleteChangeId = null,
+                DeleteReplaceSeq = null,
+                PcasLine = "N"
+            });
+        }
+
+        private void UpdateNode(BomTreeNode node, BomChange change)
+        {
+            var detail = this.bomDetailRepository.FindById(int.Parse(node.Id));
+            if (detail.Qty != node.Qty || detail.GenerateRequirement != node.Requirement)
+            {
+                if (detail.AddChange.DocumentNumber != change.DocumentNumber)
+                {
+                    throw new InvalidBomChangeException(
+                        "Can't directly update details added by a different CRF - Replace them instead!");
+                }
+
+                detail.Qty = node.Qty;
+                detail.GenerateRequirement = node.Requirement;
+            }
+        }
+
+        private void DeleteNode(BomTreeNode node, BomChange change)
+        {
+            var detail = this.bomDetailRepository.FindById(int.Parse(node.Id));
+            if (detail.DeleteChangeId.HasValue
+                && detail.DeleteChange?.DocumentNumber != change.DocumentNumber)
+            {
+                throw new InvalidBomChangeException(
+                    $"{node.Name} is already marked for deletion by another change request"
+                    + $" ({detail.DeleteChange?.DocumentNumber})");
+            }
+
+            if (detail.PcasLine == "Y")
+            {
+                throw new InvalidBomChangeException($"{node.Name} is a PCAS line - cannot delete here.");
+            }
+
+            if (detail?.AddChange?.DocumentNumber == change.DocumentNumber)
+            {
+                this.bomDetailRepository.Remove(detail);
+
+                if (detail.AddReplaceSeq.HasValue)
+                {
+                    var replacedDetail = this.bomDetailRepository.FindBy(
+                        x => x.DeleteChangeId == change.ChangeId
+                             && x.DeleteReplaceSeq == detail.AddReplaceSeq);
+                    replacedDetail.DeleteReplaceSeq = null;
+                    replacedDetail.DeleteChangeId = null;
+                }
+            }
+            else
+            {
+                detail.DeleteChangeId = change.ChangeId;
+            }
+        }
+
+        private void UndoNodeDeletion(BomTreeNode node)
+        {
+            node.DeleteChangeDocumentNumber = null;
+            this.bomDetailRepository.FindById(int.Parse(node.Id)).DeleteChangeId = null;
+        }
+
+        private void DoNodeReplacement(BomTreeNode node, BomTreeNode replacement, BomChange change, int seq)
+        {
+            if (replacement == null)
+            {
+                throw new InvalidBomChangeException(
+                    $"{node.Name} is marked for replacement but no replacement part is specified");
+            }
+
+            var replacedDetail = this.bomDetailRepository.FindById(int.Parse(node.Id));
+
+            if (node.AddChangeDocumentNumber == change.DocumentNumber)
+            {
+                throw new InvalidBomChangeException(
+                    $"{node.Name} was added by the current change request - no need to replace it - just edit it directly.");
+            }
+
+            if (replacement.Name == change.BomName)
+            {
+                throw new InvalidBomChangeException($"Can't add {replacement.Name} to it's own BOM!");
+            }
+
+            if (replacedDetail.PcasLine == "Y")
+            {
+                throw new InvalidBomChangeException(
+                    $"{node.Name} is a PCAS line - cannot replace here.");
+            }
+
+            replacedDetail.DeleteChangeId = change.ChangeId;
+            replacedDetail.DeleteReplaceSeq = seq + 1;
+            replacedDetail.ChangeState = "PROPOS";
         }
 
         private BomChange GetOrCreateBomChange(string bomName, int crfNumber, int changedBy)

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -60,7 +60,7 @@
                     {
                         var bom = this.GetOrCreateBom(current.Name);
                         var change = this.GetOrCreateBomChange(current.Name, changeRequestNumber, enteredBy, bom);
-                        this.ProcessBomChangeForSubAssembly(current, change, bom);
+                        this.ProcessBomChange(current, change, bom);
                         current.HasChanged = false;
                     }
 
@@ -109,7 +109,7 @@
             this.bomPack.ExplodeSubAssembly(change.BomId, change.ChangeId, change.ChangeState, subAssembly);
         }
 
-        private void ProcessBomChangeForSubAssembly(BomTreeNode current, BomChange change, Bom bom)
+        private void ProcessBomChange(BomTreeNode current, BomChange change, Bom bom)
         {
             var detailsOnChange = this.bomDetailRepository
                 .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -111,7 +111,6 @@
 
         private void ProcessBomChangeForSubAssembly(BomTreeNode current, BomChange change, Bom bom)
         {
-            // initialise replacement seq to be the max replacement seq currently on this change
             var detailsOnChange = this.bomDetailRepository
                 .FilterBy(x => x.BomId == change.BomId && x.AddChangeId == change.ChangeId);
             var replacementSeq = !detailsOnChange.Any() ? 0
@@ -308,7 +307,6 @@
         {
             var bomLookup = this.bomRepository.FindBy(x => x.BomName == name);
 
-            // create a bom if required
             var bom = bomLookup ?? new Bom
                                        {
                                            BomId = this.databaseService.GetIdSequence("BOM_SEQ"),

--- a/src/Domain.LinnApps/Boms/BomTreeService.cs
+++ b/src/Domain.LinnApps/Boms/BomTreeService.cs
@@ -1,6 +1,5 @@
 ﻿namespace Linn.Purchasing.Domain.LinnApps.Boms
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -97,7 +96,10 @@
                     current.Children = current.Children?.Select(
                         child =>
                             {
-
+                                if (child.Name == "PCSM 219/L1R1")
+                                {
+                                    var x = "stop";
+                                }
                                 var children = child.Type != "C" ? this.detailViewRepository
                                     .FilterBy(x => x.BomName == child.Name)
                                     .Where(x => showChanges || x.ChangeState == "LIVE")
@@ -128,7 +130,6 @@
                                         .OrderBy(x => x.Part.PartNumber)
                                         .Select(
                                             detail =>
-
                                                 new BomTreeNode
                                                     {
                                                         Name = detail.Part.PartNumber,
@@ -137,9 +138,9 @@
                                                         Type = detail.Part.BomType,
                                                         ParentName = detail.BomPartNumber,
                                                         ParentId = detail.BomId.ToString(),
-                                                        Requirement = child.Requirement,
-                                                        SafetyCritical = child.SafetyCritical,
-                                                        DrawingReference = child.DrawingReference,
+                                                        Requirement = detail.GenerateRequirement,
+                                                        SafetyCritical = detail.Part.SafetyCritical,
+                                                        DrawingReference = detail.Part.DrawingReference,
                                                         AddChangeDocumentNumber = detail.AddChange.DocumentNumber,
                                                         DeleteChangeDocumentNumber = detail.DeleteChange != null ?
                                                             detail.DeleteChange.DocumentNumber : null,

--- a/src/Domain.LinnApps/Boms/BomTreeService.cs
+++ b/src/Domain.LinnApps/Boms/BomTreeService.cs
@@ -96,15 +96,11 @@
                     current.Children = current.Children?.Select(
                         child =>
                             {
-                                if (child.Name == "PCSM 219/L1R1")
-                                {
-                                    var x = "stop";
-                                }
                                 var children = child.Type != "C" ? this.detailViewRepository
-                                    .FilterBy(x => x.BomName == child.Name)
-                                    .Where(x => showChanges || x.ChangeState == "LIVE")
-                                    .Where(c => !requirementOnly
-                                                || (c.PartRequirement != null && c.PartRequirement.AnnualUsage > 0))
+                                                       .FilterBy(x => x.BomName == child.Name)
+                                                       .Where(x => showChanges || x.ChangeState == "LIVE")
+                                                       .Where(c => !requirementOnly
+                                                                   || (c.PartRequirement != null && c.PartRequirement.AnnualUsage > 0))
                                                    :null;
 
                                 var node = new BomTreeNode

--- a/src/Domain.LinnApps/Boms/IBomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/IBomChangeService.cs
@@ -4,7 +4,7 @@
 
     public interface IBomChangeService
     {
-        BomTreeNode ProcessTreeUpdate(BomTreeNode tree, int changeRequestNumber, int enteredBy);
+        void ProcessTreeUpdate(BomTreeNode tree, int changeRequestNumber, int enteredBy);
 
         void CopyBom(string srcPartNumber, string destBomPartNumber, int changedBy, int crfNumber);
 

--- a/src/Domain.LinnApps/Boms/IBomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/IBomChangeService.cs
@@ -4,7 +4,7 @@
 
     public interface IBomChangeService
     {
-        BomTreeNode CreateBomChanges(BomTreeNode tree, int changeRequestNumber, int enteredBy);
+        BomTreeNode ProcessTreeUpdate(BomTreeNode tree, int changeRequestNumber, int enteredBy);
 
         void CopyBom(string srcPartNumber, string destBomPartNumber, int changedBy, int crfNumber);
 

--- a/src/Facade/Services/BomFacadeService.cs
+++ b/src/Facade/Services/BomFacadeService.cs
@@ -29,12 +29,12 @@
         {
             try
             {
-                var result = this.bomChangeService.CreateBomChanges(
+                var result = this.bomChangeService.ProcessTreeUpdate(
                     resource.TreeRoot,
                     resource.CrNumber,
                     resource.EnteredBy);
                 this.transactionManager.Commit();
-                return new SuccessResult<BomTreeNode>(result);
+                return new SuccessResult<BomTreeNode>(this.treeService.BuildBomTree(result.Name, null, false, true));
             }
             catch (DomainException e)
             {

--- a/src/Facade/Services/BomFacadeService.cs
+++ b/src/Facade/Services/BomFacadeService.cs
@@ -29,12 +29,12 @@
         {
             try
             {
-                var result = this.bomChangeService.ProcessTreeUpdate(
+                this.bomChangeService.ProcessTreeUpdate(
                     resource.TreeRoot,
                     resource.CrNumber,
                     resource.EnteredBy);
                 this.transactionManager.Commit();
-                return new SuccessResult<BomTreeNode>(this.treeService.BuildBomTree(result.Name, null, false, true));
+                return new SuccessResult<BomTreeNode>(this.treeService.BuildBomTree(resource.TreeRoot.Name, null, false, true));
             }
             catch (DomainException e)
             {

--- a/src/Proxy/BomPack.cs
+++ b/src/Proxy/BomPack.cs
@@ -23,6 +23,7 @@
         public void CopyBom(
             string srcPartNumber, int destBomId, int destChangeId, string destChangeState, string addOrOverWrite)
         {
+            this.transactionManager.Commit();
             using (var connection = this.databaseService.GetConnection())
             {
                 connection.Open();

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -120,7 +120,6 @@ function BomUtility() {
         e.preventDefault();
         const { target } = e;
         const detail = selected.children.find(x => x.id === target.id);
-
         setContextMenu(
             crNumber && contextMenu === null
                 ? {
@@ -233,7 +232,7 @@ function BomUtility() {
         },
         {
             field: 'addReplaceSeq',
-            headerName: 'Seq',
+            headerName: 'In',
             width: 75,
             editable: false
         },
@@ -256,14 +255,14 @@ function BomUtility() {
         },
         {
             field: 'deleteReplaceSeq',
-            headerName: 'Seq',
+            headerName: 'Out',
             width: 75,
             editable: false
         },
         {
             field: 'drawingReference',
             headerName: 'Drawing Ref',
-            width: 200,
+            width: 150,
             editable: false
         },
         {
@@ -580,6 +579,7 @@ function BomUtility() {
                     variant="contained"
                     onClick={() => {
                         setExplodeSubAssemblyDialogOpen(false);
+                        setCopyBomDialogOpen(false);
                         setPartSearchTerm(null);
                         if (copyBomDialogOpen) {
                             reduxDispatch(
@@ -894,13 +894,13 @@ function BomUtility() {
                         </Grid>
                     </>
                 )}
-                <Grid item xs={4} height="30px">
+                <Grid item xs={3} height="30px">
                     {subAssemblyLoading && <LinearProgress />}
                 </Grid>
-                <Grid item xs={8} height="30px" />
+                <Grid item xs={9} height="30px" />
                 <Grid
                     item
-                    xs={4}
+                    xs={3}
                     sx={{
                         height: '85vh',
                         overflowY: bomTreeLoading ? 'hidden' : 'scroll',
@@ -927,7 +927,7 @@ function BomUtility() {
                 </Grid>
                 <Grid
                     item
-                    xs={8}
+                    xs={9}
                     sx={{
                         paddingTop: '0px ! important',
                         height: '85vh',
@@ -958,7 +958,6 @@ function BomUtility() {
                         hideFooter
                         autoHeight
                         experimentalFeatures={{ newEditingApi: true }}
-                        checkboxSelection
                         disableSelectionOnClick
                         columns={columns}
                         getRowClassName={params => params.row.changeState?.toLowerCase()}

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -307,6 +307,7 @@ function BomUtility() {
                     } else {
                         let replacedIndex = null;
                         let replacementFor = null;
+                        let replacedNode = null;
                         current.children = current.children.map((x, index) => {
                             if (x.id !== newNode.id) {
                                 if (
@@ -327,16 +328,19 @@ function BomUtility() {
                             if (newNode.isReplaced) {
                                 replacedIndex = index;
                                 replacementFor = x.id;
+                                replacedNode = newNode;
                             }
                             return { ...newNode, changeState: 'PROPOS' };
                         });
                         if (replacedIndex !== null) {
                             current.children.splice(replacedIndex + 1, 0, {
+                                ...replacedNode,
                                 id: uid(),
-                                type: 'C',
                                 parentId: current.id,
                                 changeState: 'PROPOS',
-                                replacementFor
+                                replacementFor,
+                                isReplaced: false,
+                                addChangeDocumentNumber: null
                             });
                         }
                     }

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -119,14 +119,20 @@ function BomUtility() {
     const onContextMenu = e => {
         e.preventDefault();
         const { target } = e;
-        const detail = selected.children.find(x => x.name === target.innerText);
+        const detail = selected.children.find(x => x.id === target.id);
+
         setContextMenu(
             crNumber && contextMenu === null
                 ? {
                       mouseX: e.clientX + 2,
                       mouseY: e.clientY - 6,
                       part: target.innerText,
-                      canReplace: Number(crNumber) !== detail.addChangeDocumentNumber,
+                      canDelete: !detail.deleteReplaceSeq,
+                      canReplace:
+                          Number(crNumber) !== detail.addChangeDocumentNumber &&
+                          !detail.addReplaceSeq &&
+                          !detail.deleteReplaceSeq &&
+                          !detail.replacementFor,
                       detail: { ...detail, parentId: selected.id }
                   }
                 : null
@@ -135,9 +141,9 @@ function BomUtility() {
 
     const partLookUpCell = params => (
         <>
-            <span onContextMenu={crNumber ? onContextMenu : null}>
+            <span id={params.row.id} onContextMenu={crNumber ? onContextMenu : null}>
                 {params.row.isReplaced || params.row.toDelete ? (
-                    <s>{params.row.name}</s>
+                    <s id={params.row.id}>{params.row.name}</s>
                 ) : (
                     params.row.name
                 )}
@@ -961,7 +967,9 @@ function BomUtility() {
                             >
                                 REPLACE
                             </MenuItem>
-                            <MenuItem onClick={handleDeleteClick}>DELETE</MenuItem>
+                            <MenuItem disabled={!contextMenu.canDelete} onClick={handleDeleteClick}>
+                                DELETE
+                            </MenuItem>
                         </Menu>
                     )}
                     <Grid item xs={1}>

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -174,7 +174,7 @@ function BomUtility() {
         {
             field: 'name',
             headerName: 'Part',
-            width: 150,
+            width: 175,
             editable: false,
             renderCell: partLookUpCell,
             align: 'right'
@@ -220,8 +220,8 @@ function BomUtility() {
         },
         {
             field: 'addChangeDocumentNumber',
-            headerName: 'Add CRF',
-            width: 100,
+            headerName: 'Add',
+            width: 75,
             hide: !showChanges,
             editable: false,
             renderCell: params => (
@@ -238,8 +238,8 @@ function BomUtility() {
         },
         {
             field: 'deleteChangeDocumentNumber',
-            headerName: 'Del CRF',
-            width: 100,
+            headerName: 'Del',
+            width: 75,
             hide: !showChanges,
             editable: false,
             renderCell: params =>
@@ -263,7 +263,8 @@ function BomUtility() {
             field: 'drawingReference',
             headerName: 'Drawing Ref',
             width: 150,
-            editable: false
+            editable: false,
+            hide: true
         },
         {
             field: 'replacementFor',
@@ -894,13 +895,13 @@ function BomUtility() {
                         </Grid>
                     </>
                 )}
-                <Grid item xs={3} height="30px">
+                <Grid item xs={4} height="30px">
                     {subAssemblyLoading && <LinearProgress />}
                 </Grid>
-                <Grid item xs={9} height="30px" />
+                <Grid item xs={8} height="30px" />
                 <Grid
                     item
-                    xs={3}
+                    xs={4}
                     sx={{
                         height: '85vh',
                         overflowY: bomTreeLoading ? 'hidden' : 'scroll',
@@ -927,7 +928,7 @@ function BomUtility() {
                 </Grid>
                 <Grid
                     item
-                    xs={9}
+                    xs={8}
                     sx={{
                         paddingTop: '0px ! important',
                         height: '85vh',

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -182,6 +182,7 @@ function BomUtility() {
         {
             field: 'description',
             headerName: 'Description',
+            hide: true,
             width: 250,
             editable: false,
             renderCell: params =>
@@ -265,27 +266,6 @@ function BomUtility() {
             width: 150,
             editable: false,
             hide: true
-        },
-        {
-            field: 'replacementFor',
-            headerName: 'Replacing',
-            width: 180,
-            editable: false,
-            hide: true // useful for debugging, but hidden generally
-        },
-        {
-            field: 'replacedBy',
-            headerName: 'Replaced By',
-            width: 180,
-            editable: false,
-            hide: true // useful for debugging, but hidden generally,
-        },
-        {
-            field: 'parentId',
-            headerName: 'Parent',
-            width: 180,
-            editable: false,
-            hide: true // useful for debugging, but hidden generally
         }
     ];
     const initialise = useCallback(() => {

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -164,7 +164,7 @@ function BomUtility() {
             field: 'type',
             headerName: 'Type',
             editable: false,
-            width: 100,
+            width: 75,
             renderCell: params =>
                 params.row.isReplaced || params.row.toDelete ? (
                     <s>{params.row.type}</s>
@@ -175,7 +175,7 @@ function BomUtility() {
         {
             field: 'name',
             headerName: 'Part',
-            width: 180,
+            width: 150,
             editable: false,
             renderCell: partLookUpCell,
             align: 'right'
@@ -183,7 +183,7 @@ function BomUtility() {
         {
             field: 'description',
             headerName: 'Description',
-            width: 500,
+            width: 250,
             editable: false,
             renderCell: params =>
                 params.row.isReplaced || params.row.toDelete ? (
@@ -195,13 +195,13 @@ function BomUtility() {
         {
             field: 'safetyCritical',
             headerName: 'Safety',
-            width: 100,
+            width: 75,
             editable: false
         },
         {
             field: 'qty',
             headerName: 'Qty',
-            width: 100,
+            width: 75,
             editable: true,
             type: 'number',
             renderCell: params =>
@@ -214,20 +214,15 @@ function BomUtility() {
         {
             field: 'requirement',
             headerName: 'Req',
+            width: 75,
             editable: true,
             type: 'singleSelect',
             valueOptions: ['Y', 'N']
         },
         {
-            field: 'drawingReference',
-            headerName: 'Drawing Ref',
-            width: 200,
-            editable: false
-        },
-        {
             field: 'addChangeDocumentNumber',
             headerName: 'Add CRF',
-            width: 150,
+            width: 100,
             hide: !showChanges,
             editable: false,
             renderCell: params => (
@@ -237,9 +232,15 @@ function BomUtility() {
             )
         },
         {
+            field: 'addReplaceSeq',
+            headerName: 'Seq',
+            width: 75,
+            editable: false
+        },
+        {
             field: 'deleteChangeDocumentNumber',
             headerName: 'Del CRF',
-            width: 150,
+            width: 100,
             hide: !showChanges,
             editable: false,
             renderCell: params =>
@@ -252,6 +253,18 @@ function BomUtility() {
                 ) : (
                     <span>{params.row.deleteChangeDocumentNumber}</span>
                 )
+        },
+        {
+            field: 'deleteReplaceSeq',
+            headerName: 'Seq',
+            width: 75,
+            editable: false
+        },
+        {
+            field: 'drawingReference',
+            headerName: 'Drawing Ref',
+            width: 200,
+            editable: false
         },
         {
             field: 'replacementFor',

--- a/tests/Integration/Integration.Tests/BomModuleTests/WhenPostingBom.cs
+++ b/tests/Integration/Integration.Tests/BomModuleTests/WhenPostingBom.cs
@@ -40,7 +40,7 @@
                                     TreeRoot = this.tree
                                 };
 
-            this.BomChangeService.CreateBomChanges(
+            this.BomChangeService.ProcessTreeUpdate(
                 Arg.Any<BomTreeNode>(),
                 4567,
                 Arg.Any<int>()).Returns(this.resource.TreeRoot);

--- a/tests/Integration/Integration.Tests/BomModuleTests/WhenPostingBom.cs
+++ b/tests/Integration/Integration.Tests/BomModuleTests/WhenPostingBom.cs
@@ -40,10 +40,8 @@
                                     TreeRoot = this.tree
                                 };
 
-            this.BomChangeService.ProcessTreeUpdate(
-                Arg.Any<BomTreeNode>(),
-                4567,
-                Arg.Any<int>()).Returns(this.resource.TreeRoot);
+            this.BomTreeService.BuildBomTree(this.resource.TreeRoot.Name, null, false, true)
+                .Returns(this.tree);
 
             this.Response = this.Client.PostAsJsonAsync(
                 $"/purchasing/boms/tree",

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingAPartToItsOwnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingAPartToItsOwnBom.cs
@@ -38,9 +38,10 @@
                         BomId = 123, 
                         Details = new List<BomDetailViewEntry>()
                     });
+            this.BomDetailRepository.FindById(Arg.Any<int>()).Returns(new BomDetail());
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
-            this.action = () => this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingDetailToSubAssembly.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingDetailToSubAssembly.cs
@@ -75,7 +75,7 @@
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
             this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(1, 2);
             this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(1, 2);
-            this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoBomType.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoBomType.cs
@@ -37,7 +37,7 @@
                     });
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { BomType = string.Empty, DecrementRule = "YES" });
-            this.action = () => this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoDecrementRule.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoDecrementRule.cs
@@ -34,7 +34,7 @@
                 new Bom { BomName = "BOM", BomId = 123, Details = new List<BomDetailViewEntry>() });
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { BomType = "C" });
-            this.action = () => this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPhasedOutPartToBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPhasedOutPartToBom.cs
@@ -34,7 +34,7 @@
                 new Bom { BomName = "BOM", BomId = 123, Details = new List<BomDetailViewEntry>() });
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DatePurchPhasedOut = DateTime.Today });
-            this.action = () => this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingToBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingToBom.cs
@@ -65,6 +65,12 @@
                     Details = new List<BomDetailViewEntry>()
                 },
                 new Bom
+                    {
+                        BomName = "BOM",
+                        BomId = 123,
+                        Details = new List<BomDetailViewEntry>()
+                    },
+                new Bom
                 {
                     BomName = "ASS 1",
                     BomId = 456,
@@ -74,7 +80,7 @@
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
             this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(1, 2);
             this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(1, 2, 3);
-            this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingToBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingToBom.cs
@@ -65,12 +65,6 @@
                     Details = new List<BomDetailViewEntry>()
                 },
                 new Bom
-                    {
-                        BomName = "BOM",
-                        BomId = 123,
-                        Details = new List<BomDetailViewEntry>()
-                    },
-                new Bom
                 {
                     BomName = "ASS 1",
                     BomId = 456,

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenBomChangeForInvalidPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenBomChangeForInvalidPart.cs
@@ -9,6 +9,8 @@
     using Linn.Purchasing.Domain.LinnApps.Boms;
     using Linn.Purchasing.Domain.LinnApps.Boms.Models;
     using Linn.Purchasing.Domain.LinnApps.Exceptions;
+    using Linn.Purchasing.Domain.LinnApps.Parts;
+
     using NSubstitute;
 
     using NUnit.Framework;
@@ -28,10 +30,9 @@
                                HasChanged = true,
                                Children = new List<BomTreeNode> { new BomTreeNode { Name = "CAP 001", ParentName = "BOM" } }
                            };
-
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
                 new Bom { BomName = "BOM", BomId = 123, Details = new List<BomDetailViewEntry>() });
-            this.action = () => this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenCreatingNewBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenCreatingNewBom.cs
@@ -35,7 +35,7 @@
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(this.part);
 
-            this.result = this.Sut.ProcessTreeUpdate(
+            this.Sut.ProcessTreeUpdate(
                 new BomTreeNode
                     {
                         Name = "NEW BOM", HasChanged = true, Children = new List<BomTreeNode>()

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenCreatingNewBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenCreatingNewBom.cs
@@ -35,7 +35,7 @@
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(this.part);
 
-            this.result = this.Sut.CreateBomChanges(
+            this.result = this.Sut.ProcessTreeUpdate(
                 new BomTreeNode
                     {
                         Name = "NEW BOM", HasChanged = true, Children = new List<BomTreeNode>()

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAPcasLine.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAPcasLine.cs
@@ -56,7 +56,8 @@
                                           {
                                               PartNumber = "ASS 1",
                                               Qty = 2,
-                                              ChangeState = "LIVE"
+                                              ChangeState = "LIVE",
+                                              DetailId = 4567
                                           }
                                   }
             });
@@ -75,7 +76,7 @@
                 .Returns(this.deletedDetail);
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { PartNumber = "ASS 1" });
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailAddedByThisChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailAddedByThisChangeRequest.cs
@@ -23,8 +23,6 @@
 
         private BomDetail deletedDetail;
 
-        private BomTreeNode result;
-
         [SetUp]
         public void SetUp()
         {
@@ -77,7 +75,7 @@
                 .Returns(this.deletedDetail);
             this.BomChangeRepository.FindBy(Arg.Any<Expression<Func<BomChange, bool>>>())
                 .Returns(new BomChange { ChangeId = 123, DocumentNumber = 666 });
-            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 666, 33087);
+            this.Sut.ProcessTreeUpdate(this.newTree, 666, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailAddedByThisChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailAddedByThisChangeRequest.cs
@@ -56,7 +56,8 @@
                                           {
                                               PartNumber = "ASS 1",
                                               Qty = 2,
-                                              ChangeState = "LIVE"
+                                              ChangeState = "LIVE",
+                                              DetailId = 4567
                                           }
                                   }
             });
@@ -76,19 +77,13 @@
                 .Returns(this.deletedDetail);
             this.BomChangeRepository.FindBy(Arg.Any<Expression<Func<BomChange, bool>>>())
                 .Returns(new BomChange { ChangeId = 123, DocumentNumber = 666 });
-            this.result = this.Sut.CreateBomChanges(this.newTree, 666, 33087);
+            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 666, 33087);
         }
 
         [Test]
         public void ShouldDeleteDetail()
         {
             this.BomDetailRepository.Received().Remove(Arg.Is<BomDetail>(x => x.DetailId == 4567));
-        }
-
-        [Test]
-        public void ShouldReturnTreeWithoutDeletedDetail()
-        {
-            this.result.Children.Count().Should().Be(0);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailThatWasAddedByAnotherChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailThatWasAddedByAnotherChangeRequest.cs
@@ -21,8 +21,6 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
 
         private BomDetail deletedDetail;
 
-        private BomTreeNode result;
-
         [SetUp]
         public void SetUp()
         {
@@ -75,7 +73,7 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                 .Returns(this.deletedDetail);
             this.BomChangeRepository.FindBy(Arg.Any<Expression<Func<BomChange, bool>>>())
                 .Returns(new BomChange { ChangeId = 999, DocumentNumber = 666 });
-            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 666, 33087);
+            this.Sut.ProcessTreeUpdate(this.newTree, 666, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailThatWasAddedByAnotherChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailThatWasAddedByAnotherChangeRequest.cs
@@ -54,7 +54,8 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                                           {
                                               PartNumber = "ASS 1",
                                               Qty = 2,
-                                              ChangeState = "LIVE"
+                                              ChangeState = "LIVE",
+                                              DetailId = 4567
                                           }
                                   }
             });
@@ -74,19 +75,13 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                 .Returns(this.deletedDetail);
             this.BomChangeRepository.FindBy(Arg.Any<Expression<Func<BomChange, bool>>>())
                 .Returns(new BomChange { ChangeId = 999, DocumentNumber = 666 });
-            this.result = this.Sut.CreateBomChanges(this.newTree, 666, 33087);
+            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 666, 33087);
         }
 
         [Test]
         public void ShouldUpdateDetail()
         {
             this.deletedDetail.DeleteChangeId.Should().Be(999);
-        }
-
-        [Test]
-        public void SHouldReturnUpdatedTree()
-        {
-            this.result.Children.First().DeleteChangeDocumentNumber.Should().Be(666);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
@@ -76,7 +76,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.deletedDetail);
 
-            this.result = this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
@@ -23,8 +23,6 @@
 
         private BomDetail deletedDetail;
 
-        private BomTreeNode result;
-
         [SetUp]
         public void SetUp()
         {
@@ -75,20 +73,14 @@
                                      };
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.deletedDetail);
-
-            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
+            
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]
         public void ShouldUndoDelete()
         {
             this.deletedDetail.DeleteChangeId.Should().BeNull();
-        }
-
-        [Test]
-        public void ShouldReturnTree()
-        {
-            this.result.Children.First().DeleteChangeDocumentNumber.Should().BeNull();
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
@@ -31,7 +31,7 @@
                                         Type = "A",
                                         Qty = 2,
                                         Name = "ASS 1",
-                                        ChangeState = "PROPOS",
+                                        ChangeState = "LIVE",
                                         ParentName = "BOM",
                                         ToDelete = true,
                                         Id = "4567",
@@ -56,7 +56,7 @@
                                           {
                                               PartNumber = "ASS 1",
                                               Qty = 2,
-                                              ChangeState = "PROPOS"
+                                              ChangeState = "LIVE"
                                           }
                                   }
                 });
@@ -67,7 +67,8 @@
             this.deletedDetail = new BomDetail
                                      {
                                          PartNumber = "ASS 1", 
-                                         Qty = 2, ChangeState = "PROPOS",
+                                         Qty = 2, 
+                                         ChangeState = "LIVE",
                                          DetailId = 4567,
                                          AddChange = new BomChange { ChangeId = 123 }
                                      };

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartThatIsAlreadyMarkedForDeletionByAnotherCrf.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartThatIsAlreadyMarkedForDeletionByAnotherCrf.cs
@@ -56,7 +56,8 @@
                                           {
                                               PartNumber = "ASS 1",
                                               Qty = 2,
-                                              ChangeState = "LIVE"
+                                              ChangeState = "LIVE",
+                                              DetailId = 4567
                                           }
                                   }
             });
@@ -77,7 +78,7 @@
                 .Returns(this.deletedDetail);
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { PartNumber = "ASS 1" });
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenMakingChangesToMultipleBoms.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenMakingChangesToMultipleBoms.cs
@@ -77,6 +77,19 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                                            } 
                                   }
                 },
+                new Bom 
+                    {
+                        BomName = "BOM",
+                        BomId = 123,
+                        Details = new List<BomDetailViewEntry>
+                                      {
+                                          new BomDetailViewEntry
+                                              {
+                                                  PartNumber = "ASS 1",
+                                                  DetailId = 345
+                                              }
+                                      }
+                    },
                 new Bom
                 {
                     BomName = "ASS 1",
@@ -88,7 +101,7 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
             this.BomDetailRepository.FindById(345).Returns(new BomDetail { Qty = 2, GenerateRequirement = "Y" });
             this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(1, 2);
             this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(1, 2, 3);
-            this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenMakingChangesToMultipleBoms.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenMakingChangesToMultipleBoms.cs
@@ -77,19 +77,6 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                                            } 
                                   }
                 },
-                new Bom 
-                    {
-                        BomName = "BOM",
-                        BomId = 123,
-                        Details = new List<BomDetailViewEntry>
-                                      {
-                                          new BomDetailViewEntry
-                                              {
-                                                  PartNumber = "ASS 1",
-                                                  DetailId = 345
-                                              }
-                                      }
-                    },
                 new Bom
                 {
                     BomName = "ASS 1",
@@ -126,14 +113,6 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
         {
             this.BomDetailRepository.Received(2).Add(Arg.Any<BomDetail>());
             this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
-                x => x.PartNumber == this.c11.Name
-                     && x.Qty == this.c11.Qty
-                     && x.ChangeState == "PROPOS"
-                     && x.DetailId == 2
-                     && !x.DeleteChangeId.HasValue
-                     && x.BomId == 456
-                     && x.AddChangeId == 2));
-            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
                 x => x.PartNumber == this.c12.Name
                      && x.Qty == this.c12.Qty
                      && x.ChangeState == "PROPOS"
@@ -141,6 +120,14 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                      && !x.DeleteChangeId.HasValue
                      && x.BomId == 123
                      && x.AddChangeId == 1));
+            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
+                x => x.PartNumber == this.c11.Name
+                     && x.Qty == this.c11.Qty
+                     && x.ChangeState == "PROPOS"
+                     && x.DetailId == 2
+                     && !x.DeleteChangeId.HasValue
+                     && x.BomId == 456
+                     && x.AddChangeId == 2));
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenPartMarkedForReplacementButNoReplacementSpecified.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenPartMarkedForReplacementButNoReplacementSpecified.cs
@@ -91,7 +91,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingAPartOnItsOwnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingAPartOnItsOwnBom.cs
@@ -77,7 +77,7 @@
             this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(6666);
             this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(10023);
             this.BomChangeRepository.FindBy(Arg.Any<Expression<Func<BomChange, bool>>>())
-                .Returns(new BomChange { DocumentNumber = 666 });
+                .Returns(new BomChange { DocumentNumber = 666, BomName = "BOM" });
             this.replacedDetail = new BomDetail
                                       {
                                           PartNumber = "CAP OLD", 
@@ -92,7 +92,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultipleOnChangeThatAlreadyHasReplaces.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultipleOnChangeThatAlreadyHasReplaces.cs
@@ -171,11 +171,11 @@
         {
             this.replacedDetail1.DeleteReplaceSeq.Should().Be(4);
             this.replacedDetail1.DeleteChangeId.Should().Be(6666);
-            this.replacedDetail1.ChangeState.Should().Be("PROPOS");
+            this.replacedDetail1.ChangeState.Should().Be("LIVE");
 
             this.replacedDetail2.DeleteReplaceSeq.Should().Be(5);
             this.replacedDetail2.DeleteChangeId.Should().Be(6666);
-            this.replacedDetail2.ChangeState.Should().Be("PROPOS");
+            this.replacedDetail2.ChangeState.Should().Be("LIVE");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultipleOnChangeThatAlreadyHasReplaces.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultipleOnChangeThatAlreadyHasReplaces.cs
@@ -1,0 +1,182 @@
+﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    using FluentAssertions;
+
+    using Linn.Purchasing.Domain.LinnApps.Boms;
+    using Linn.Purchasing.Domain.LinnApps.Boms.Models;
+    using Linn.Purchasing.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenReplacingMultipleOnChangeThatAlreadyHasReplaces : ContextBase
+    {
+        private BomTreeNode newTree;
+
+        private BomTreeNode c1;
+
+        private BomTreeNode c2;
+
+        private BomTreeNode c3;
+
+        private BomTreeNode c4;
+
+        private BomDetail replacedDetail1;
+
+        private BomDetail replacedDetail2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.c1 = new BomTreeNode
+            {
+                Type = "C",
+                Qty = 2,
+                Name = "CAP 1 OLD",
+                HasChanged = true,
+                ReplacedBy = "CAP 1 NEW",
+                Id = "4567"
+            };
+
+            this.c2 = new BomTreeNode
+            {
+                Type = "C",
+                Qty = 2,
+                Name = "CAP 1 NEW",
+                HasChanged = true,
+                Id = "4566",
+                ReplacementFor = "4567"
+            };
+
+            this.c3 = new BomTreeNode
+            {
+                Type = "C",
+                Qty = 2,
+                Name = "CAP 2 OLD",
+                HasChanged = true,
+                ReplacedBy = "CAP 2 NEW",
+                Id = "4568"
+            };
+
+            this.c4 = new BomTreeNode
+            {
+                Type = "C",
+                Qty = 2,
+                Name = "CAP 2 NEW",
+                HasChanged = true,
+                Id = "4655",
+                ReplacementFor = "4568"
+            };
+
+            this.newTree = new BomTreeNode
+            {
+                Name = "BOM",
+                Qty = 1,
+                Type = "A",
+                HasChanged = true,
+                Children = new List<BomTreeNode> { this.c1, this.c2, this.c3, this.c4 }
+            };
+            this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom
+            {
+                BomId = 100,
+                BomName = "BOM",
+                Details = new List<BomDetailViewEntry>
+                                  {
+                                        new BomDetailViewEntry
+                                            {
+                                                PartNumber = "CAP 1 OLD",
+                                                Qty = 2,
+                                                ChangeState = "LIVE",
+                                                DetailId = 4567
+                                            },
+                                        new BomDetailViewEntry
+                                            {
+                                                PartNumber = "CAP 2 OLD",
+                                                Qty = 2,
+                                                ChangeState = "LIVE",
+                                                DetailId = 4568
+                                            }
+                                  }
+            });
+            this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(6666);
+            this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(10023, 10024);
+
+            this.replacedDetail1 = new BomDetail
+            {
+                PartNumber = "CAP OLD",
+                Qty = 2,
+                ChangeState = "LIVE",
+                AddChange = new BomChange { DocumentNumber = 999 }
+            };
+            this.replacedDetail2 = new BomDetail
+            {
+                PartNumber = "CAP OLD",
+                Qty = 2,
+                ChangeState = "LIVE",
+                AddChange = new BomChange { DocumentNumber = 999 }
+            };
+            this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
+                .Returns(new Part { DecrementRule = "YES", BomType = "C" });
+
+            this.BomDetailRepository.FilterBy(Arg.Any<Expression<Func<BomDetail, bool>>>())
+                .Returns(new List<BomDetail>
+                             {
+                                 new BomDetail
+                                     {
+                                         AddReplaceSeq = 3
+                                     }
+                             }.AsQueryable());
+            this.BomDetailRepository.FindById(4567)
+                .Returns(this.replacedDetail1);
+            this.BomDetailRepository.FindById(4568)
+                .Returns(this.replacedDetail2);
+
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
+        }
+
+        [Test]
+        public void ShouldAddReplacementDetailsIncrementingSeq()
+        {
+            this.BomDetailRepository.Received(2).Add(Arg.Any<BomDetail>());
+            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
+                x => x.PartNumber == this.c2.Name
+                     && x.Qty == this.c2.Qty
+                     && x.ChangeState == "PROPOS"
+                     && x.AddChangeId == 6666
+                     && x.AddReplaceSeq == 4
+                     && x.DetailId == 10023
+                     && !x.DeleteChangeId.HasValue
+                     && !x.DeleteReplaceSeq.HasValue
+                     && x.BomId == 100));
+            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
+                x => x.PartNumber == this.c4.Name
+                     && x.Qty == this.c4.Qty
+                     && x.ChangeState == "PROPOS"
+                     && x.AddChangeId == 6666
+                     && x.AddReplaceSeq == 5
+                     && x.DetailId == 10024
+                     && !x.DeleteChangeId.HasValue
+                     && !x.DeleteReplaceSeq.HasValue
+                     && x.BomId == 100));
+        }
+
+        [Test]
+        public void ShouldUpdateReplacedDetail()
+        {
+            this.replacedDetail1.DeleteReplaceSeq.Should().Be(4);
+            this.replacedDetail1.DeleteChangeId.Should().Be(6666);
+            this.replacedDetail1.ChangeState.Should().Be("PROPOS");
+
+            this.replacedDetail2.DeleteReplaceSeq.Should().Be(5);
+            this.replacedDetail2.DeleteChangeId.Should().Be(6666);
+            this.replacedDetail2.ChangeState.Should().Be("PROPOS");
+        }
+    }
+}
+

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
@@ -1,0 +1,207 @@
+﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    using FluentAssertions;
+
+    using Linn.Purchasing.Domain.LinnApps.Boms;
+    using Linn.Purchasing.Domain.LinnApps.Boms.Models;
+    using Linn.Purchasing.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenReplacingMultiplePartsOnBom : ContextBase
+    {
+        private BomTreeNode newTree;
+
+        private BomTreeNode c1;
+
+        private BomTreeNode c2;
+
+        private BomTreeNode c3;
+
+        private BomTreeNode c4;
+
+        private BomDetail replacedDetail1;
+
+        private BomDetail replacedDetail2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.c1 = new BomTreeNode
+            {
+                Type = "C",
+                Qty = 2,
+                Name = "CAP 1 OLD",
+                HasChanged = true,
+                ReplacedBy = "CAP 1 NEW",
+                Id = "4567"
+            };
+
+            this.c2 = new BomTreeNode
+            {
+                Type = "C",
+                Qty = 2,
+                Name = "CAP 1 NEW",
+                HasChanged = true,
+                Id = "4566",
+                ReplacementFor = "4567"
+            };
+
+            this.c3 = new BomTreeNode
+                          {
+                              Type = "C",
+                              Qty = 2,
+                              Name = "CAP 2 OLD",
+                              HasChanged = true,
+                              ReplacedBy = "CAP 2 NEW",
+                              Id = "4568"
+                          };
+
+            this.c4 = new BomTreeNode
+                          {
+                              Type = "C",
+                              Qty = 2,
+                              Name = "CAP 2 NEW",
+                              HasChanged = true,
+                              Id = "4655",
+                              ReplacementFor = "4568"
+                          };
+
+            this.newTree = new BomTreeNode
+            {
+                Name = "BOM",
+                Qty = 1,
+                Type = "A",
+                HasChanged = true,
+                Children = new List<BomTreeNode> { this.c1, this.c2, this.c3, this.c4 }
+            };
+            this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom
+            {
+                BomId = 100,
+                BomName = "BOM",
+                Details = new List<BomDetailViewEntry>
+                                  {
+                                        new BomDetailViewEntry
+                                            {
+                                                PartNumber = "CAP 1 OLD",
+                                                Qty = 2,
+                                                ChangeState = "LIVE",
+                                                DetailId = 4567
+                                            },
+                                        new BomDetailViewEntry
+                                            {
+                                                PartNumber = "CAP 2 OLD",
+                                                Qty = 2,
+                                                ChangeState = "LIVE",
+                                                DetailId = 4568
+                                            }
+                                  }
+            });
+            this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(6666);
+            this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(10023, 10024);
+
+            this.replacedDetail1 = new BomDetail
+            {
+                PartNumber = "CAP OLD",
+                Qty = 2,
+                ChangeState = "LIVE",
+                AddChange = new BomChange { DocumentNumber = 999 }
+            };
+            this.replacedDetail2 = new BomDetail
+                                       {
+                                           PartNumber = "CAP OLD",
+                                           Qty = 2,
+                                           ChangeState = "LIVE",
+                                           AddChange = new BomChange { DocumentNumber = 999 }
+                                       };
+            this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
+                .Returns(new Part { DecrementRule = "YES", BomType = "C" });
+            var first = new List<BomDetail>
+                            {
+                                new BomDetail
+                                    {
+                                        PartNumber = "CAP 1 OLD", 
+                                        Qty = 2, ChangeState = "LIVE", 
+                                        DetailId = 4567
+                                    },
+                                new BomDetail
+                                    {
+                                        PartNumber = "CAP 2 OLD", 
+                                        Qty = 2, 
+                                        ChangeState = "LIVE", 
+                                        DetailId = 4568
+                                    }
+                            };
+            var arr = new BomDetail[2];
+            first.CopyTo(arr);
+            var second = arr.Append(new BomDetail
+                           {
+                               PartNumber = "CAP 1 NEW", Qty = 2, ChangeState = "LIVE", AddReplaceSeq = 1
+                           });
+
+            this.BomDetailRepository.FilterBy(Arg.Any<Expression<Func<BomDetail, bool>>>())
+                .Returns(first.AsQueryable(), first.AsQueryable(), second.AsQueryable());
+            this.BomDetailRepository.FindById(4567)
+                .Returns(this.replacedDetail1);
+            this.BomDetailRepository.FindById(4568)
+                .Returns(this.replacedDetail2);
+
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
+        }
+
+        [Test]
+        public void ShouldAddBomChange()
+        {
+            this.BomChangeRepository
+                .Received(1).Add(Arg.Any<BomChange>());
+            this.BomChangeRepository
+                .Received(1).Add(Arg.Is<BomChange>(c => c.BomName == "BOM" && c.DocumentNumber == 100));
+        }
+
+        [Test]
+        public void ShouldAddReplacementDetails()
+        {
+            this.BomDetailRepository.Received(2).Add(Arg.Any<BomDetail>());
+            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
+                x => x.PartNumber == this.c2.Name
+                     && x.Qty == this.c2.Qty
+                     && x.ChangeState == "PROPOS"
+                     && x.AddChangeId == 6666
+                     && x.AddReplaceSeq == 1
+                     && x.DetailId == 10023
+                     && !x.DeleteChangeId.HasValue
+                     && !x.DeleteReplaceSeq.HasValue
+                     && x.BomId == 100));
+            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
+                x => x.PartNumber == this.c4.Name
+                     && x.Qty == this.c4.Qty
+                     && x.ChangeState == "PROPOS"
+                     && x.AddChangeId == 6666
+                     && x.AddReplaceSeq == 2
+                     && x.DetailId == 10024
+                     && !x.DeleteChangeId.HasValue
+                     && !x.DeleteReplaceSeq.HasValue
+                     && x.BomId == 100));
+        }
+
+        [Test]
+        public void ShouldUpdateReplacedDetail()
+        {
+            this.replacedDetail1.DeleteReplaceSeq.Should().Be(1);
+            this.replacedDetail1.DeleteChangeId.Should().Be(6666);
+            this.replacedDetail1.ChangeState.Should().Be("PROPOS");
+
+            this.replacedDetail2.DeleteReplaceSeq.Should().Be(2);
+            this.replacedDetail2.DeleteChangeId.Should().Be(6666);
+            this.replacedDetail2.ChangeState.Should().Be("PROPOS");
+        }
+    }
+}
+

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
@@ -174,11 +174,11 @@
         {
             this.replacedDetail1.DeleteReplaceSeq.Should().Be(1);
             this.replacedDetail1.DeleteChangeId.Should().Be(6666);
-            this.replacedDetail1.ChangeState.Should().Be("PROPOS");
+            this.replacedDetail1.ChangeState.Should().Be("LIVE");
 
             this.replacedDetail2.DeleteReplaceSeq.Should().Be(2);
             this.replacedDetail2.DeleteChangeId.Should().Be(6666);
-            this.replacedDetail2.ChangeState.Should().Be("PROPOS");
+            this.replacedDetail2.ChangeState.Should().Be("LIVE");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
@@ -123,31 +123,9 @@
                                        };
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
-            var first = new List<BomDetail>
-                            {
-                                new BomDetail
-                                    {
-                                        PartNumber = "CAP 1 OLD", 
-                                        Qty = 2, ChangeState = "LIVE", 
-                                        DetailId = 4567
-                                    },
-                                new BomDetail
-                                    {
-                                        PartNumber = "CAP 2 OLD", 
-                                        Qty = 2, 
-                                        ChangeState = "LIVE", 
-                                        DetailId = 4568
-                                    }
-                            };
-            var arr = new BomDetail[2];
-            first.CopyTo(arr);
-            var second = arr.Append(new BomDetail
-                           {
-                               PartNumber = "CAP 1 NEW", Qty = 2, ChangeState = "LIVE", AddReplaceSeq = 1
-                           });
-
+            
             this.BomDetailRepository.FilterBy(Arg.Any<Expression<Func<BomDetail, bool>>>())
-                .Returns(first.AsQueryable(), first.AsQueryable(), second.AsQueryable());
+                .Returns(new List<BomDetail>().AsQueryable());
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail1);
             this.BomDetailRepository.FindById(4568)

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
@@ -91,15 +91,6 @@
         }
 
         [Test]
-        public void ShouldAddBomChange()
-        {
-            this.BomChangeRepository
-                .Received(1).Add(Arg.Any<BomChange>());
-            this.BomChangeRepository
-                .Received(1).Add(Arg.Is<BomChange>(c => c.BomName == "BOM" && c.DocumentNumber == 100));
-        }
-
-        [Test]
         public void ShouldAddReplacementDetail()
         {
             this.BomDetailRepository.Received(1).Add(Arg.Any<BomDetail>());

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
@@ -87,7 +87,7 @@
                 .Returns(this.replacedDetail);
             this.BomDetailRepository.FilterBy(Arg.Any<Expression<Func<BomDetail, bool>>>())
                 .Returns(new List<BomDetail> { new BomDetail { AddReplaceSeq = 2 } }.AsQueryable());
-            this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
@@ -111,7 +111,7 @@
         {
             this.replacedDetail.DeleteReplaceSeq.Should().Be(3);
             this.replacedDetail.DeleteChangeId.Should().Be(6666);
-            this.replacedDetail.ChangeState.Should().Be("PROPOS");
+            this.replacedDetail.ChangeState.Should().Be("LIVE");
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartThatWasAddedByTheCurrentChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartThatWasAddedByTheCurrentChangeRequest.cs
@@ -91,7 +91,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartWithPhasedOutPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartWithPhasedOutPart.cs
@@ -89,7 +89,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPcasPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPcasPart.cs
@@ -83,15 +83,16 @@
                                           Qty = 2, 
                                           ChangeState = "LIVE", 
                                           PcasLine = "Y",
+                                          DetailId = 4567,
                                           AddChange = new BomChange { DocumentNumber = 999 }
                                       };
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
 
-            this.BomDetailRepository.FindById(10023)
+            this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoBomType.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoBomType.cs
@@ -90,7 +90,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoDecrementRule.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoDecrementRule.cs
@@ -90,7 +90,7 @@
             this.BomDetailRepository.FindById(4567)
                 .Returns(this.replacedDetail);
 
-            this.action = () => this.Sut.CreateBomChanges(this.newTree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUndoingAReplacementMadeOnThisChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUndoingAReplacementMadeOnThisChangeRequest.cs
@@ -29,8 +29,6 @@
 
         private BomChange bomChange;
 
-        private BomTreeNode result;
-
         [SetUp]
         public void SetUp()
         {
@@ -131,7 +129,7 @@
             this.BomDetailRepository
                 .FindBy(Arg.Any<Expression<Func<BomDetail, bool>>>()).Returns(this.replacedToUndo);
 
-            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 48451, 33879);
+            this.Sut.ProcessTreeUpdate(this.newTree, 48451, 33879);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUndoingAReplacementMadeOnThisChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUndoingAReplacementMadeOnThisChangeRequest.cs
@@ -131,7 +131,7 @@
             this.BomDetailRepository
                 .FindBy(Arg.Any<Expression<Func<BomDetail, bool>>>()).Returns(this.replacedToUndo);
 
-            this.result = this.Sut.CreateBomChanges(this.newTree, 48451, 33879);
+            this.result = this.Sut.ProcessTreeUpdate(this.newTree, 48451, 33879);
         }
 
         [Test]
@@ -145,14 +145,6 @@
         {
             this.replacedToUndo.DeleteReplaceSeq.Should().BeNull();
             this.replacedToUndo.DeleteChangeId.Should().BeNull();
-        }
-
-        [Test]
-        public void ShouldReturnUpdatedTree()
-        {
-            this.result.Children.Count().Should().Be(1);
-            this.result.Children.First().DeleteChangeDocumentNumber.Should().BeNull();
-            this.result.Children.First().DeleteReplaceSeq.Should().BeNull();
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFields.cs
@@ -17,7 +17,7 @@
 
     public class WhenUpdatingExistingDetailFields : ContextBase
     {
-        private BomTreeNode result;
+        private BomDetail detail;
 
         [SetUp]
         public void SetUp()
@@ -39,13 +39,14 @@
                                                     }
                                               },
             };
-            this.BomDetailRepository.FindById(123).Returns(new BomDetail
-                                                               {
-                                                                   DetailId = 123, 
-                                                                   Qty = 1, 
-                                                                   AddChangeId = 666,
-                                                                   AddChange = new BomChange { DocumentNumber = 100 }
-                                                               });
+            this.detail = new BomDetail
+                              {
+                                  DetailId = 123,
+                                  Qty = 1,
+                                  AddChangeId = 666,
+                                  AddChange = new BomChange {DocumentNumber = 100}
+                              };
+            this.BomDetailRepository.FindById(123).Returns(this.detail);
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
                 new Bom
                 {
@@ -57,13 +58,13 @@
                 .Returns(new BomChange { ChangeId = 666, DocumentNumber = 100 });
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
-            this.result = this.Sut.ProcessTreeUpdate(tree, 100, 33087);
+            this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]
         public void ShouldUpdateField()
         {
-            this.result.Children.First().Qty.Should().Be(2);
+            this.detail.Qty.Should().Be(2);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFields.cs
@@ -39,7 +39,13 @@
                                                     }
                                               },
             };
-            this.BomDetailRepository.FindById(123).Returns(new BomDetail { DetailId = 123, Qty = 1, AddChangeId = 666 });
+            this.BomDetailRepository.FindById(123).Returns(new BomDetail
+                                                               {
+                                                                   DetailId = 123, 
+                                                                   Qty = 1, 
+                                                                   AddChangeId = 666,
+                                                                   AddChange = new BomChange { DocumentNumber = 100 }
+                                                               });
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
                 new Bom
                 {
@@ -48,10 +54,10 @@
                     Details = new List<BomDetailViewEntry> { new BomDetailViewEntry { DetailId = 123, Qty = 1 } }
                 });
             this.BomChangeRepository.FindBy(Arg.Any<Expression<Func<BomChange, bool>>>())
-                .Returns(new BomChange { ChangeId = 666 });
+                .Returns(new BomChange { ChangeId = 666, DocumentNumber = 100 });
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
-            this.result = this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.result = this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFieldsButDetailWasAddedByDifferentCrf.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFieldsButDetailWasAddedByDifferentCrf.cs
@@ -32,11 +32,19 @@
                                               { 
                                                   new BomTreeNode
                                                     {
-                                                        Name = "CAP 530", ParentName = "BOM", Id = "123", Type = "C"
+                                                        Name = "CAP 530", 
+                                                        ParentName = "BOM", 
+                                                        Id = "123", 
+                                                        Type = "C"
                                                     }
                                               },
                            };
-            this.BomDetailRepository.FindById(123).Returns(new BomDetail { DetailId = 123, Qty = 1, AddChangeId = 666 });
+            this.BomDetailRepository.FindById(123).Returns(new BomDetail
+                                                               {
+                                                                   DetailId = 123, Qty = 1, 
+                                                                   AddChangeId = 666, 
+                                                                   AddChange = new BomChange()
+                                                               });
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
                 new Bom
                     {
@@ -47,7 +55,7 @@
             this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(111);
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
                 .Returns(new Part { DecrementRule = "YES", BomType = "C" });
-            this.action = () => this.Sut.CreateBomChanges(tree, 100, 33087);
+            this.action = () => this.Sut.ProcessTreeUpdate(tree, 100, 33087);
         }
 
         [Test]


### PR DESCRIPTION
 - mainly just a big refactor of the BomChangeService (which github has handily hidden since the diff is so big - make sure you expand that one out if you are reviewing to see what I actually changed)
 - the general idea was to split out the messy spaghetti of the main 'ProcessTreeUpdate' method  into hopefully more understandable smaller methods. One for traversing, one for processing each sub assembly, and then specialised ones for the different kinds of updates we do to bom tree nodes (add, delete, undo delete, replace)
 - I also removed the added complexity of keeping the tree (in memory) up to date and returning that to the client. Now the state of the tree in the db is the single source of truth, and I query the database after any updates commit to guarantee the most-up-to-date tree is returned to the client - trade off is I have to hit the db again obviosuly to rebuild the tree, which makes the PostBomTree request a bit slower.
 - all kinds of bug fixes