### PR TITLE
Misc tickets

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrderReqs/PurchaseOrderReqService.cs
+++ b/src/Domain.LinnApps/PurchaseOrderReqs/PurchaseOrderReqService.cs
@@ -165,6 +165,12 @@
 
             var totalInBaseCurr = this.currencyPack.CalculateBaseValueFromCurrencyValue(entity.CurrencyCode, entity.TotalReqPrice.Value);
 
+            if (entity.Carriage.GetValueOrDefault() > 0)
+            {
+                var distributedCarriage = entity.Carriage / entity.Qty;
+                entity.UnitPrice += distributedCarriage.GetValueOrDefault();
+            }
+
             var authAllowed = this.purchaseOrdersPack.OrderCanBeAuthorisedBy(
                 null,
                 null,

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -213,16 +213,24 @@
                     throw new PurchaseOrderException("Cannot Order Non-Live Part!");
                 }
 
-                var nominalCode = detail.OrderPosting.NominalAccount.NominalCode;
+                var nominal = detail.OrderPosting.NominalAccount;
 
-                var nominalAccount = this.nominalAccountRepository.FindBy(
-                                         x => x.NominalCode == nominalCode) 
-                                     ?? this.nominalAccountRepository.FindBy(
-                                         x => x.NominalCode.EndsWith(nominalCode));
+                var nominalAccounts = this.nominalAccountRepository.FilterBy(x => x.NominalCode == nominal.NominalCode);
+
+                if (!nominalAccounts.Any())
+                {
+                    nominalAccounts = this.nominalAccountRepository.FilterBy(
+                        x => x.NominalCode.EndsWith(nominal.NominalCode));
+                }
+
+                var nominalAccount = nominalAccounts.FirstOrDefault(
+                                         x => x.DepartmentCode == nominal.DepartmentCode)
+                                     ?? nominalAccounts.FirstOrDefault(
+                                         x => x.DepartmentCode.EndsWith(nominal.DepartmentCode));
 
                 if (nominalAccount == null)
                 {
-                    throw new ItemNotFoundException("Invalid nominal code: " + nominalCode);
+                    throw new ItemNotFoundException("Invalid nominal code/dept");
                 }
 
                 detail.OrderPosting.NominalAccount = nominalAccount;

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -213,6 +213,20 @@
                     throw new PurchaseOrderException("Cannot Order Non-Live Part!");
                 }
 
+                var nominalCode = detail.OrderPosting.NominalAccount.NominalCode;
+
+                var nominalAccount = this.nominalAccountRepository.FindBy(
+                                         x => x.NominalCode == nominalCode) 
+                                     ?? this.nominalAccountRepository.FindBy(
+                                         x => x.NominalCode.EndsWith(nominalCode));
+
+                if (nominalAccount == null)
+                {
+                    throw new ItemNotFoundException("Invalid nominal code: " + nominalCode);
+                }
+
+                detail.OrderPosting.NominalAccount = nominalAccount;
+
                 this.SetDetailFieldsForCreation(detail, newOrderNumber);
 
                 this.PerformDetailCalculations(

--- a/src/Facade/Services/PurchaseOrderFacadeService.cs
+++ b/src/Facade/Services/PurchaseOrderFacadeService.cs
@@ -541,8 +541,9 @@
                                                                        LineNumber = x.OrderPosting.LineNumber,
                                                                        NominalAccount = new NominalAccount
                                                                            {
-                                                                               NominalCode = x.OrderPosting.NominalAccount.Nominal.NominalCode
-                                                                           },
+                                                                               NominalCode = x.OrderPosting.NominalAccount.Nominal.NominalCode,
+                                                                               DepartmentCode = x.OrderPosting.NominalAccount.Department.DepartmentCode
+                                                                       },
                                                                        Notes = x.OrderPosting.Notes,
                                                                        OrderNumber = x.OrderNumber,
                                                                        Person = x.OrderPosting.Person,

--- a/src/Facade/Services/PurchaseOrderFacadeService.cs
+++ b/src/Facade/Services/PurchaseOrderFacadeService.cs
@@ -9,6 +9,7 @@
     using Linn.Common.Facade;
     using Linn.Common.Logging;
     using Linn.Common.Persistence;
+    using Linn.Purchasing.Domain.LinnApps;
     using Linn.Purchasing.Domain.LinnApps.Parts;
     using Linn.Purchasing.Domain.LinnApps.PurchaseOrders;
     using Linn.Purchasing.Domain.LinnApps.Suppliers;
@@ -538,8 +539,7 @@
                                                                        Building = x.OrderPosting.Building,
                                                                        Id = x.OrderPosting.Id,
                                                                        LineNumber = x.OrderPosting.LineNumber,
-                                                                       NominalAccountId =
-                                                                           x.OrderPosting.NominalAccountId,
+                                                                       NominalAccount = new NominalAccount { NominalCode = x.OrderPosting.NominalAccount.Nominal.NominalCode },
                                                                        Notes = x.OrderPosting.Notes,
                                                                        OrderNumber = x.OrderNumber,
                                                                        Person = x.OrderPosting.Person,

--- a/src/Facade/Services/PurchaseOrderFacadeService.cs
+++ b/src/Facade/Services/PurchaseOrderFacadeService.cs
@@ -539,7 +539,10 @@
                                                                        Building = x.OrderPosting.Building,
                                                                        Id = x.OrderPosting.Id,
                                                                        LineNumber = x.OrderPosting.LineNumber,
-                                                                       NominalAccount = new NominalAccount { NominalCode = x.OrderPosting.NominalAccount.Nominal.NominalCode },
+                                                                       NominalAccount = new NominalAccount
+                                                                           {
+                                                                               NominalCode = x.OrderPosting.NominalAccount.Nominal.NominalCode
+                                                                           },
                                                                        Notes = x.OrderPosting.Notes,
                                                                        OrderNumber = x.OrderNumber,
                                                                        Person = x.OrderPosting.Person,

--- a/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
@@ -152,6 +152,10 @@ function PurchaseOrderUtility({ creating }) {
         itemSelectorHelpers.getItemLoading(state[purchaseOrderDeliveries.item])
     );
 
+    const suggestedValuesError = useSelector(state =>
+        getItemError(state, suggestedPurchaseOrderValues.item)
+    );
+
     const itemError = useSelector(state => getItemError(state, purchaseOrder.item));
 
     const deptEmailError = useSelector(state =>
@@ -553,6 +557,16 @@ function PurchaseOrderUtility({ creating }) {
                                         <ErrorCard
                                             errorMessage={
                                                 itemError?.details?.error ?? itemError.statusText
+                                            }
+                                        />
+                                    </Grid>
+                                )}
+                                {suggestedValuesError && (
+                                    <Grid item xs={12}>
+                                        <ErrorCard
+                                            errorMessage={
+                                                suggestedValuesError?.details?.error ??
+                                                suggestedValuesError.statusText
                                             }
                                         />
                                     </Grid>

--- a/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
@@ -76,8 +76,8 @@ function PurchaseOrderUtility({ creating }) {
     const { orderNumber } = useParams();
     const loc = useLocation();
 
-    const [deptCode, setDeptCode] = useState('');
-    const [deptDesc, setDeptDesc] = useState('');
+    // const [deptCode, setDeptCode] = useState('');
+    // const [deptDesc, setDeptDesc] = useState('');
 
     useEffect(() => {
         if (orderNumber) {
@@ -291,7 +291,8 @@ function PurchaseOrderUtility({ creating }) {
                 d.partNumber &&
                 d.ourQty &&
                 d.ourUnitOfMeasure &&
-                d.orderPosting?.nominalAccount?.nominal?.nominalCode
+                d.orderPosting?.nominalAccount?.nominal?.nominalCode &&
+                d.orderPosting?.nominalAccount?.department?.departmentCode
         ) &&
         order.currency.code &&
         order.deliveryAddress?.addressId;
@@ -563,7 +564,7 @@ function PurchaseOrderUtility({ creating }) {
                                     <Grid item xs={12}>
                                         <ErrorCard
                                             errorMessage={
-                                                itemError?.details ?? itemError.statusText
+                                                itemError?.details?.error ?? itemError.statusText
                                             }
                                         />
                                     </Grid>
@@ -1657,14 +1658,21 @@ function PurchaseOrderUtility({ creating }) {
                                             <Grid item xs={4}>
                                                 <Typeahead
                                                     onSelect={newValue => {
-                                                        setDeptCode(newValue.departmentCode);
-                                                        setDeptDesc(newValue.departmentDescription);
+                                                        dispatch({
+                                                            payload: newValue.departmentCode,
+                                                            lineNumber: detail.line,
+                                                            type: 'departmentCodeChange'
+                                                        });
                                                     }}
                                                     label="Search Departments"
                                                     modal
                                                     openModalOnClick={false}
                                                     handleFieldChange={(_, newValue) => {
-                                                        setDeptCode(newValue);
+                                                        dispatch({
+                                                            payload: newValue,
+                                                            lineNumber: detail.line,
+                                                            type: 'departmentCodeChange'
+                                                        });
                                                     }}
                                                     propertyName="deptCode"
                                                     items={[
@@ -1678,7 +1686,10 @@ function PurchaseOrderUtility({ creating }) {
                                                             s => s.departmentCode === r
                                                         )
                                                     }))}
-                                                    value={deptCode}
+                                                    value={
+                                                        detail.orderPosting?.nominalAccount
+                                                            ?.department?.departmentCode
+                                                    }
                                                     loading={nominalsSearchLoading}
                                                     fetchItems={searchTerm =>
                                                         reduxDispatch(
@@ -1698,7 +1709,7 @@ function PurchaseOrderUtility({ creating }) {
                                                     fullWidth
                                                     value={
                                                         detail.orderPosting?.nominalAccount
-                                                            ?.department?.description || deptDesc
+                                                            ?.department?.description
                                                     }
                                                     label="Description"
                                                     disabled
@@ -1711,10 +1722,11 @@ function PurchaseOrderUtility({ creating }) {
                                                         handleNominalUpdate(newValue, detail.line);
                                                     }}
                                                     handleFieldChange={(_, newValue) => {
-                                                        handleNominalUpdate(
-                                                            { nominalCode: newValue },
-                                                            detail.line
-                                                        );
+                                                        dispatch({
+                                                            payload: newValue,
+                                                            lineNumber: detail.line,
+                                                            type: 'nominalCodeChange'
+                                                        });
                                                     }}
                                                     label="Search Nominals"
                                                     modal
@@ -1722,8 +1734,12 @@ function PurchaseOrderUtility({ creating }) {
                                                     propertyName="nominalCode"
                                                     items={nominalSearchResults.filter(
                                                         x =>
-                                                            !deptCode ||
-                                                            x.departmentCode.endsWith(deptCode)
+                                                            !detail.orderPosting?.nominalAccount
+                                                                ?.department?.departmentCode ||
+                                                            x.departmentCode.endsWith(
+                                                                detail.orderPosting?.nominalAccount
+                                                                    ?.department?.departmentCode
+                                                            )
                                                     )}
                                                     value={
                                                         detail.orderPosting?.nominalAccount?.nominal

--- a/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
@@ -184,7 +184,7 @@ function PurchaseOrderUtility({ creating }) {
         } else if (creating && suggestedValues) {
             reduxDispatch(purchaseOrderActions.clearErrorsForItem());
             dispatch({ type: 'initialise', payload: suggestedValues });
-            if (suggestedValues.notesForBuyer) {
+            if (suggestedValues?.notesForBuyer?.replace('\r', '').replace('\n', '').trim()) {
                 setSupplierNotesOpen(true);
             }
 
@@ -291,7 +291,6 @@ function PurchaseOrderUtility({ creating }) {
                 d.partNumber &&
                 d.ourQty &&
                 d.ourUnitOfMeasure &&
-                d.orderPosting?.nominalAccount?.department?.departmentCode &&
                 d.orderPosting?.nominalAccount?.nominal?.nominalCode
         ) &&
         order.currency.code &&
@@ -317,7 +316,7 @@ function PurchaseOrderUtility({ creating }) {
         dispatch({ payload: { ...detail, [propertyName]: newValue }, type: 'detailFieldChange' });
     };
 
-    const handleCurrencyChange = (propertyName, newCurrencyCode) => {
+    const handleCurrencyChange = (_, newCurrencyCode) => {
         reduxDispatch(purchaseOrderActions.setEditStatus('edit'));
 
         const name = currencies.find(x => x.code === newCurrencyCode)?.name;
@@ -1711,8 +1710,15 @@ function PurchaseOrderUtility({ creating }) {
                                                     onSelect={newValue => {
                                                         handleNominalUpdate(newValue, detail.line);
                                                     }}
+                                                    handleFieldChange={(_, newValue) => {
+                                                        handleNominalUpdate(
+                                                            { nominalCode: newValue },
+                                                            detail.line
+                                                        );
+                                                    }}
                                                     label="Search Nominals"
                                                     modal
+                                                    openModalOnClick={false}
                                                     propertyName="nominalCode"
                                                     items={nominalSearchResults.filter(
                                                         x =>

--- a/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/PurchaseOrderUtility.js
@@ -75,9 +75,6 @@ function PurchaseOrderUtility({ creating }) {
     const { orderNumber } = useParams();
     const loc = useLocation();
 
-    // const [deptCode, setDeptCode] = useState('');
-    // const [deptDesc, setDeptDesc] = useState('');
-
     useEffect(() => {
         if (orderNumber) {
             reduxDispatch(sendPurchaseOrderDeptEmailActions.clearErrorsForItem());

--- a/src/Service.Host/client/src/components/PurchaseOrders/purchaseOrderReducer.js
+++ b/src/Service.Host/client/src/components/PurchaseOrders/purchaseOrderReducer.js
@@ -107,6 +107,48 @@ export default function purchaseOrderReducer(state = initialState, action) {
                     })
                 ]
             };
+        case 'departmentCodeChange':
+            return {
+                ...state,
+                details: [
+                    ...state.details.map(detail => {
+                        if (detail.line !== action.lineNumber) {
+                            return detail;
+                        }
+                        return {
+                            ...detail,
+                            orderPosting: {
+                                ...detail.orderPosting,
+                                nominalAccount: {
+                                    ...detail.orderPosting.nominalAccount,
+                                    department: { departmentCode: action.payload }
+                                }
+                            }
+                        };
+                    })
+                ]
+            };
+        case 'nominalCodeChange':
+            return {
+                ...state,
+                details: [
+                    ...state.details.map(detail => {
+                        if (detail.line !== action.lineNumber) {
+                            return detail;
+                        }
+                        return {
+                            ...detail,
+                            orderPosting: {
+                                ...detail.orderPosting,
+                                nominalAccount: {
+                                    ...detail.orderPosting.nominalAccount,
+                                    nominal: { nominalCode: action.payload }
+                                }
+                            }
+                        };
+                    })
+                ]
+            };
         case 'supplierChange':
             return {
                 ...state,

--- a/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingCreditOrder.cs
+++ b/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingCreditOrder.cs
@@ -39,7 +39,10 @@
                                             = new PurchaseOrderPostingResource
                                                   {
                                                       NominalAccount =
-                                                          new NominalAccountResource(),
+                                                          new NominalAccountResource
+                                                              {
+                                                                  Nominal = new NominalResource()
+                                                              }
                                                          }
                                     }
                               },
@@ -57,7 +60,10 @@
                 .Returns(new Supplier());
 
             this.MockNominalAccountRepository.FindById(Arg.Any<int>())
-                .Returns(new NominalAccount());
+                .Returns(new NominalAccount
+                             {
+                                 Nominal = new Nominal()
+                             });
 
             this.MockDomainService.CreateOrder(
                     Arg.Any<PurchaseOrder>(), Arg.Any<IEnumerable<string>>())

--- a/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingCreditOrder.cs
+++ b/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingCreditOrder.cs
@@ -41,7 +41,8 @@
                                                       NominalAccount =
                                                           new NominalAccountResource
                                                               {
-                                                                  Nominal = new NominalResource()
+                                                                  Nominal = new NominalResource(),
+                                                                  Department = new DepartmentResource()
                                                               }
                                                          }
                                     }

--- a/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingReturnsOrder.cs
+++ b/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingReturnsOrder.cs
@@ -39,7 +39,10 @@
                                             = new PurchaseOrderPostingResource
                                                   {
                                                       NominalAccount =
-                                                          new NominalAccountResource(),
+                                                          new NominalAccountResource
+                                                              {
+                                                                  Nominal = new NominalResource()
+                                                              },
                                                          }
                                     }
                               },
@@ -57,7 +60,7 @@
                 .Returns(new Supplier());
 
             this.MockNominalAccountRepository.FindById(Arg.Any<int>())
-                .Returns(new NominalAccount());
+                .Returns(new NominalAccount { Nominal = new Nominal() });
 
             this.MockDomainService.CreateOrder(
                     Arg.Any<PurchaseOrder>(), Arg.Any<IEnumerable<string>>())

--- a/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingReturnsOrder.cs
+++ b/tests/Integration/Integration.Tests/PurchaseOrderModuleTests/WhenCreatingReturnsOrder.cs
@@ -41,7 +41,8 @@
                                                       NominalAccount =
                                                           new NominalAccountResource
                                                               {
-                                                                  Nominal = new NominalResource()
+                                                                  Nominal = new NominalResource(),
+                                                                  Department = new DepartmentResource()
                                                               },
                                                          }
                                     }

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderReqServiceTests/WhenCreatingOrderFromReq.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderReqServiceTests/WhenCreatingOrderFromReq.cs
@@ -13,7 +13,7 @@
 
     using NUnit.Framework;
 
-    public class WhenTurningIntoMiniOrder : ContextBase
+    public class WhenCreatingOrderFromReq : ContextBase
     {
         private readonly int authoriserUserNumber = 33107;
 
@@ -40,7 +40,6 @@
                                   Description = "Descrip",
                                   Qty = 7,
                                   UnitPrice = 8m,
-                                  Carriage = 99m,
                                   TotalReqPrice = 145m,
                                   CurrencyCode = "SMC",
                                   SupplierId = 111,

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderReqServiceTests/WhenCreatingOrderFromReqAndCarriageValue.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderReqServiceTests/WhenCreatingOrderFromReqAndCarriageValue.cs
@@ -1,0 +1,139 @@
+﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.PurchaseOrderReqServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+
+    using FluentAssertions;
+    using FluentAssertions.Extensions;
+
+    using Linn.Purchasing.Domain.LinnApps.PurchaseOrderReqs;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenCreatingOrderFromReqAndCarriageValue : ContextBase
+    {
+        private readonly int authoriserUserNumber = 33107;
+
+        private readonly string fromState = "ORDER WAIT";
+
+        private readonly int newOrderNumber = 101137;
+
+        private readonly int reqNumber = 5678;
+
+        private readonly string toState = "ORDER";
+
+        private PurchaseOrderReq entity;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.entity = new PurchaseOrderReq
+            {
+                ReqNumber = this.reqNumber,
+                State = this.fromState,
+                ReqDate = 2.March(2022),
+                OrderNumber = 1234,
+                PartNumber = "PCAS 007",
+                Description = "Descrip",
+                Qty = 10,
+                Carriage = 12.50m,
+                UnitPrice = 8m,
+                TotalReqPrice = 145m,
+                CurrencyCode = "SMC",
+                SupplierId = 111,
+                SupplierName = "the things shop",
+                SupplierContact = "Lawrence Chaney",
+                AddressLine1 = "The shop",
+                AddressLine2 = "1 Main Street",
+                AddressLine3 = "town centre",
+                AddressLine4 = "Glesga",
+                PostCode = "G1 1AA",
+                CountryCode = "GB",
+                PhoneNumber = "+44 1234567780",
+                QuoteRef = "blah",
+                Email = "LC@gmail",
+                DateRequired = 1.January(2023),
+                RequestedById = 33107,
+                AuthorisedById = 33107,
+                SecondAuthById = null,
+                FinanceCheckById = 33107,
+                TurnedIntoOrderById = null,
+                NominalCode = "00001234",
+                RemarksForOrder = "needed asap",
+                InternalNotes = "pls approv",
+                DepartmentCode = "00002345"
+            };
+
+            this.MockReqsStateChangeRepository.FindBy(Arg.Any<Expression<Func<PurchaseOrderReqStateChange, bool>>>())
+                .Returns(
+                    new PurchaseOrderReqStateChange
+                    {
+                        FromState = this.fromState,
+                        ToState = this.toState,
+                        ComputerAllowed = "Y",
+                        UserAllowed = "N"
+                    });
+
+            this.MockAuthService.HasPermissionFor(
+                AuthorisedAction.PurchaseOrderReqFinanceCheck,
+                Arg.Any<List<string>>()).Returns(true);
+
+            this.MockCurrencyPack.CalculateBaseValueFromCurrencyValue(
+                this.entity.CurrencyCode,
+                this.entity.TotalReqPrice.Value).Returns(145m);
+
+            this.MockPurchaseOrdersPack.OrderCanBeAuthorisedBy(
+                null,
+                null,
+                this.authoriserUserNumber,
+                145m,
+                this.entity.PartNumber,
+                "PO").Returns(true);
+
+            this.MockPurchaseOrderAutoOrderPack.CreateMiniOrderFromReq(
+                this.entity.NominalCode,
+                this.entity.DepartmentCode,
+                this.entity.RequestedById,
+                this.authoriserUserNumber,
+                this.entity.Description,
+                this.entity.QuoteRef,
+                this.entity.RemarksForOrder,
+                this.entity.PartNumber,
+                this.entity.SupplierId,
+                this.entity.Qty,
+                this.entity.DateRequired,
+                Arg.Any<decimal>(),
+                true,
+                this.entity.InternalNotes)
+                .Returns(new CreateOrderFromReqResult { OrderNumber = 101137, Success = true });
+
+            this.EmployeeRepository.FindById(this.authoriserUserNumber).Returns(
+                new Employee { FullName = "Big Jimbo", Id = this.authoriserUserNumber });
+
+            this.Sut.CreateOrderFromReq(this.entity, new List<string>(), this.authoriserUserNumber);
+        }
+
+        [Test]
+        public void ShouldDistributeCarriageCostAcrossUnitPrice()
+        {
+            this.MockPurchaseOrderAutoOrderPack.Received().CreateMiniOrderFromReq(
+                this.entity.NominalCode,
+                this.entity.DepartmentCode,
+                this.entity.RequestedById,
+                this.authoriserUserNumber,
+                this.entity.Description,
+                this.entity.QuoteRef,
+                this.entity.RemarksForOrder,
+                this.entity.PartNumber,
+                this.entity.SupplierId,
+                this.entity.Qty,
+                this.entity.DateRequired,
+                9.25m,
+                true,
+                this.entity.InternalNotes);
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingFOCPurchaseOrder.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingFOCPurchaseOrder.cs
@@ -132,7 +132,11 @@
 
             this.MockAuthService.HasPermissionFor(AuthorisedAction.PurchaseOrderCreate, Arg.Any<IEnumerable<string>>())
                 .Returns(true);
-
+            this.NominalAccountRepository.FindBy(Arg.Any<Expression<Func<NominalAccount, bool>>>())
+                .Returns(new NominalAccount
+                             {
+                                 NominalCode = "00009222"
+                            });
             this.PurchaseOrdersPack.GetVatAmountSupplier(Arg.Any<decimal>(), Arg.Any<int>()).Returns(0m);
 
             this.MockDatabaseService.GetIdSequence("PLORP_SEQ").Returns(123);

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingFOCPurchaseOrder.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingFOCPurchaseOrder.cs
@@ -79,6 +79,8 @@
                                                                                 new NominalAccount
                                                                                     {
                                                                                         AccountId = 911,
+                                                                                        DepartmentCode =
+                                                                                            "0000911",
                                                                                         Department =
                                                                                             new Department
                                                                                                 {
@@ -132,11 +134,11 @@
 
             this.MockAuthService.HasPermissionFor(AuthorisedAction.PurchaseOrderCreate, Arg.Any<IEnumerable<string>>())
                 .Returns(true);
-            this.NominalAccountRepository.FindBy(Arg.Any<Expression<Func<NominalAccount, bool>>>())
-                .Returns(new NominalAccount
+            this.NominalAccountRepository.FilterBy(Arg.Any<Expression<Func<NominalAccount, bool>>>())
+                .Returns(new List<NominalAccount>
                              {
-                                 NominalCode = "00009222"
-                            });
+                                new NominalAccount { DepartmentCode = "0000911" }
+                             }.AsQueryable());
             this.PurchaseOrdersPack.GetVatAmountSupplier(Arg.Any<decimal>(), Arg.Any<int>()).Returns(0m);
 
             this.MockDatabaseService.GetIdSequence("PLORP_SEQ").Returns(123);

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingPurchaseOrder.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingPurchaseOrder.cs
@@ -133,6 +133,12 @@
             this.MockAuthService.HasPermissionFor(AuthorisedAction.PurchaseOrderCreate, Arg.Any<IEnumerable<string>>())
                 .Returns(true);
 
+            this.NominalAccountRepository.FindBy(Arg.Any<Expression<Func<NominalAccount, bool>>>())
+                .Returns(new NominalAccount
+                             {
+                                 NominalCode = "00009222"
+                             });
+
             this.PurchaseOrdersPack.GetVatAmountSupplier(Arg.Any<decimal>(), Arg.Any<int>()).Returns(40.55m);
 
             this.MockDatabaseService.GetIdSequence("PLORP_SEQ").Returns(123);
@@ -185,6 +191,8 @@
 
             firstDetail.PurchaseDeliveries
                 .First().DateRequested.Should().Be(DateTime.UnixEpoch);
+
+            firstDetail.OrderPosting.NominalAccount.NominalCode.Should().Be("00009222");
         }
 
         [Test]

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingPurchaseOrder.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingPurchaseOrder.cs
@@ -133,11 +133,15 @@
             this.MockAuthService.HasPermissionFor(AuthorisedAction.PurchaseOrderCreate, Arg.Any<IEnumerable<string>>())
                 .Returns(true);
 
-            this.NominalAccountRepository.FindBy(Arg.Any<Expression<Func<NominalAccount, bool>>>())
-                .Returns(new NominalAccount
-                             {
-                                 NominalCode = "00009222"
-                             });
+            this.NominalAccountRepository.FilterBy(Arg.Any<Expression<Func<NominalAccount, bool>>>())
+                .Returns(
+                    new List<NominalAccount>
+                        {
+                            new NominalAccount
+                                 {
+                                     NominalCode = "00009222"
+                                 }
+                        }.AsQueryable());
 
             this.PurchaseOrdersPack.GetVatAmountSupplier(Arg.Any<decimal>(), Arg.Any<int>()).Returns(40.55m);
 


### PR DESCRIPTION
- distribute carriage price across unit prices when req is converted to order
- allow leigh to directly enter Nominal Codes since she knows em off by heart
- stops supplier notes that consist of nothing but carriage returns from triggering the popup
- addresses #508 
- change Typeaheads to Search's on the PO form