### PR TITLE
Fix extraneous bom changes bug

### DIFF
--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -55,12 +55,12 @@
                 {
                     var current = q.Dequeue();
 
-                    if (current.HasChanged.GetValueOrDefault() && current.Children != null)
+                    if (current.AssemblyHasChanges.GetValueOrDefault() && current.Children != null)
                     {
                         var bom = this.GetOrCreateBom(current.Name);
                         var change = this.GetOrCreateBomChange(current.Name, changeRequestNumber, enteredBy, bom);
                         this.ProcessBomChange(current, change, bom);
-                        current.HasChanged = false;
+                        current.AssemblyHasChanges = false;
                     }
 
                     if (current.Children != null)

--- a/src/Domain.LinnApps/Boms/Models/BomTreeNode.cs
+++ b/src/Domain.LinnApps/Boms/Models/BomTreeNode.cs
@@ -22,6 +22,8 @@
 
         public bool? HasChanged { get; set; }
 
+        public bool? AssemblyHasChanges { get; set; }
+
         public string ChangeState { get; set; }
 
         public int AddChangeDocumentNumber { get; set; }

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -309,7 +309,7 @@ function BomUtility() {
                 const current = q[0];
                 q.shift();
                 if (current.id === newNode.parentId) {
-                    current.hasChanged = true;
+                    current.assemblyHasChanges = true;
                     if (addNode) {
                         current.children = [
                             ...current.children,

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingAPartToItsOwnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingAPartToItsOwnBom.cs
@@ -27,7 +27,7 @@
                                Name = "BOM",
                                Qty = 1,
                                Type = "A",
-                               HasChanged = true,
+                               AssemblyHasChanges = true,
                                Children = new List<BomTreeNode> { new BomTreeNode { Name = "BOM", ParentName = "BOM" } },
                            };
             

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingDetailToSubAssembly.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingDetailToSubAssembly.cs
@@ -46,7 +46,7 @@
                 Name = "ASS 1",
                 ParentName = "BOM",
                 Id = "9876",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 AddChangeDocumentNumber = 123456,
                 Children = new List<BomTreeNode> { this.c11, this.c12 }
             };
@@ -55,7 +55,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = false,
+                AssemblyHasChanges = false,
                 Children = new List<BomTreeNode> { this.c1 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoBomType.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoBomType.cs
@@ -27,7 +27,7 @@
                                Name = "BOM",
                                Qty = 1,
                                Type = "A",
-                               HasChanged = true,
+                               AssemblyHasChanges = true,
                                Children = new List<BomTreeNode> { new BomTreeNode { Name = "CAP 001", ParentName = "BOM" } }
                            };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoDecrementRule.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPartWithNoDecrementRule.cs
@@ -27,7 +27,7 @@
                                Name = "BOM",
                                Qty = 1,
                                Type = "A",
-                               HasChanged = true,
+                               AssemblyHasChanges = true,
                                Children = new List<BomTreeNode> { new BomTreeNode { Name = "CAP 001", ParentName = "BOM" } }
                            };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPhasedOutPartToBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingPhasedOutPartToBom.cs
@@ -27,7 +27,7 @@
                                   Name = "BOM",
                                   Qty = 1,
                                   Type = "A",
-                                  HasChanged = true,
+                                  AssemblyHasChanges = true,
                                   Children = new List<BomTreeNode> { new BomTreeNode { Name = "CAP 001", ParentName = "BOM"} }
                               };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingSubAssemblyToBomAndSomeComponentsToThatSubAssembly.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingSubAssemblyToBomAndSomeComponentsToThatSubAssembly.cs
@@ -12,7 +12,7 @@
 
     using NUnit.Framework;
 
-    public class WhenAddingToBom : ContextBase
+    public class WhenAddingSubAssemblyToBomAndSomeComponentsToThatSubAssembly : ContextBase
     {
         private BomTreeNode newTree;
 
@@ -45,7 +45,7 @@
                              Qty = 2,
                              Name = "ASS 1",
                              ParentName = "BOM",
-                             HasChanged = true,
+                             AssemblyHasChanges = true,
                              Children = new List<BomTreeNode> { this.c11, this.c12 }
                          };
             this.newTree = new BomTreeNode
@@ -53,7 +53,7 @@
                                    Name = "BOM",
                                    Qty = 1,
                                    Type = "A",
-                                   HasChanged = true,
+                                   AssemblyHasChanges = true,
                                    Children = new List<BomTreeNode> { this.c1 }
                                };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingUnchangedSubAssemblyToBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenAddingUnchangedSubAssemblyToBom.cs
@@ -1,0 +1,92 @@
+﻿namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+
+    using Linn.Purchasing.Domain.LinnApps.Boms;
+    using Linn.Purchasing.Domain.LinnApps.Boms.Models;
+    using Linn.Purchasing.Domain.LinnApps.Parts;
+
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenAddingUnchangedSubAssemblyToBom : ContextBase
+    {
+        private BomTreeNode newTree;
+
+        private BomTreeNode subAssembly;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.subAssembly = new BomTreeNode
+                          {
+                              Type = "A",
+                              Qty = 2,
+                              Name = "ASS 1",
+                              ParentName = "BOM",
+                              Children = new List<BomTreeNode> { new BomTreeNode { Id = "666" } }
+                          };
+            this.newTree = new BomTreeNode
+            {
+                Name = "BOM",
+                Qty = 1,
+                Type = "A",
+                AssemblyHasChanges = true,
+                Children = new List<BomTreeNode> { this.subAssembly }
+            };
+
+            this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
+                new Bom
+                {
+                    BomName = "BOM",
+                    BomId = 123,
+                    Details = new List<BomDetailViewEntry>()
+                },
+                new Bom
+                    {
+                        BomName = "ASS 1",
+                        Details = new List<BomDetailViewEntry>
+                                      {
+                                          new BomDetailViewEntry { DetailId = 666 }
+                                      }
+                    });
+            this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>())
+                .Returns(new Part { PartNumber = "ASS 1", DecrementRule = "YES", BomType = "A" });
+            this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(1);
+            this.DatabaseService.GetIdSequence("BOMDET_SEQ").Returns(1);
+            this.Sut.ProcessTreeUpdate(this.newTree, 100, 33087);
+        }
+
+        [Test]
+        public void ShouldAddOneBomChange()
+        {
+            this.BomChangeRepository
+                .Received(1).Add(Arg.Any<BomChange>());
+            this.BomChangeRepository
+                .Received(1).Add(Arg.Is<BomChange>(c => c.BomName == "BOM" && c.DocumentNumber == 100));
+        }
+
+        [Test]
+        public void ShouldNotAddNewBom()
+        {
+            this.BomRepository.DidNotReceive().Add(Arg.Any<Bom>());
+        }
+
+        [Test]
+        public void ShouldAddOneBomDetail()
+        {
+            this.BomDetailRepository.Received(1).Add(Arg.Any<BomDetail>());
+            this.BomDetailRepository.Received(1).Add(Arg.Is<BomDetail>(
+                x => x.PartNumber == this.subAssembly.Name
+                     && x.Qty == this.subAssembly.Qty
+                     && x.ChangeState == "PROPOS"
+                     && x.DetailId == 1
+                     && !x.DeleteChangeId.HasValue
+                     && x.BomId == 123
+                     && x.AddChangeId == 1));
+        }
+    }
+}

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenBomChangeForInvalidPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenBomChangeForInvalidPart.cs
@@ -27,7 +27,7 @@
                                Name = "BOM",
                                Qty = 1,
                                Type = "A",
-                               HasChanged = true,
+                               AssemblyHasChanges = true,
                                Children = new List<BomTreeNode> { new BomTreeNode { Name = "CAP 001", ParentName = "BOM" } }
                            };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenCreatingNewBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenCreatingNewBom.cs
@@ -38,7 +38,7 @@
             this.Sut.ProcessTreeUpdate(
                 new BomTreeNode
                     {
-                        Name = "NEW BOM", HasChanged = true, Children = new List<BomTreeNode>()
+                        Name = "NEW BOM", AssemblyHasChanges = true, Children = new List<BomTreeNode>()
                     }, 
                 666, 
                 33087);

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAPcasLine.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAPcasLine.cs
@@ -42,7 +42,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailAddedByThisChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailAddedByThisChangeRequest.cs
@@ -40,7 +40,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailThatWasAddedByAnotherChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingDetailThatWasAddedByAnotherChangeRequest.cs
@@ -38,7 +38,7 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartFromBom.cs
@@ -42,7 +42,7 @@
                                    Name = "BOM",
                                    Qty = 1,
                                    Type = "A",
-                                   HasChanged = true,
+                                   AssemblyHasChanges = true,
                                    Children = new List<BomTreeNode> { this.c1 }
                                };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartThatIsAlreadyMarkedForDeletionByAnotherCrf.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingPartThatIsAlreadyMarkedForDeletionByAnotherCrf.cs
@@ -42,7 +42,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenMakingChangesToMultipleBoms.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenMakingChangesToMultipleBoms.cs
@@ -50,7 +50,7 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                 Id = "345",
                 ParentName = "BOM",
                 Requirement = "Y",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c11 }
             };
             this.newTree = new BomTreeNode
@@ -59,7 +59,7 @@ namespace Linn.Purchasing.Domain.LinnApps.Tests.BomChangeServiceTests
                 Qty = 1,
                 Type = "A",
                 Requirement = "Y",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c12 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenPartMarkedForReplacementButNoReplacementSpecified.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenPartMarkedForReplacementButNoReplacementSpecified.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 Id = "4567",
                 ParentName = "BOM"
@@ -46,7 +46,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Id = "56789",
                 ParentName = "BOM"
             };
@@ -56,7 +56,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>())

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingAPartOnItsOwnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingAPartOnItsOwnBom.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 Id = "4567",
                 ParentName = "BOM"
@@ -46,7 +46,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "BOM",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacementFor = "4567",
                 ParentName = "BOM",
                 Id = "123"
@@ -57,7 +57,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultipleOnChangeThatAlreadyHasReplaces.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultipleOnChangeThatAlreadyHasReplaces.cs
@@ -39,7 +39,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP 1 OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP 1 NEW",
                 Id = "4567"
             };
@@ -49,7 +49,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP 1 NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Id = "4566",
                 ReplacementFor = "4567"
             };
@@ -59,7 +59,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP 2 OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP 2 NEW",
                 Id = "4568"
             };
@@ -69,7 +69,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP 2 NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Id = "4655",
                 ReplacementFor = "4568"
             };
@@ -79,7 +79,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2, this.c3, this.c4 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingMultiplePartsOnTheBom.cs
@@ -39,7 +39,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP 1 OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP 1 NEW",
                 Id = "4567"
             };
@@ -49,7 +49,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP 1 NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Id = "4566",
                 ReplacementFor = "4567"
             };
@@ -59,7 +59,7 @@
                               Type = "C",
                               Qty = 2,
                               Name = "CAP 2 OLD",
-                              HasChanged = true,
+                              AssemblyHasChanges = true,
                               ReplacedBy = "CAP 2 NEW",
                               Id = "4568"
                           };
@@ -69,7 +69,7 @@
                               Type = "C",
                               Qty = 2,
                               Name = "CAP 2 NEW",
-                              HasChanged = true,
+                              AssemblyHasChanges = true,
                               Id = "4655",
                               ReplacementFor = "4568"
                           };
@@ -79,7 +79,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2, this.c3, this.c4 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartOnBom.cs
@@ -33,7 +33,7 @@
                               Type = "C",
                               Qty = 2,
                               Name = "CAP OLD",
-                              HasChanged = true,
+                              AssemblyHasChanges = true,
                               ReplacedBy = "CAP NEW",
                               Id = "4567"
                           };
@@ -43,7 +43,7 @@
                               Type = "C",
                               Qty = 2,
                               Name = "CAP NEW",
-                              HasChanged = true,
+                              AssemblyHasChanges = true,
                               ReplacementFor = "4567"
                           };
 
@@ -52,7 +52,7 @@
                                    Name = "BOM",
                                    Qty = 1,
                                    Type = "A",
-                                   HasChanged = true,
+                                   AssemblyHasChanges = true,
                                    Children = new List<BomTreeNode> { this.c1, this.c2 }
                                };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartThatWasAddedByTheCurrentChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartThatWasAddedByTheCurrentChangeRequest.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 AddChangeDocumentNumber = 100,
                 Id = "4567",
@@ -47,7 +47,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacementFor = "4567",
                 ParentName = "BOM"
             };
@@ -57,7 +57,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartWithPhasedOutPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPartWithPhasedOutPart.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 Id = "4567",
                 ParentName = "BOM"
@@ -46,7 +46,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacementFor = "4567",
                 ParentName = "BOM"
             };
@@ -56,7 +56,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPcasPart.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingPcasPart.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 Id = "4567",
                 ParentName = "BOM"
@@ -46,7 +46,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacementFor = "4567",
                 ParentName = "BOM"
             };
@@ -56,7 +56,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoBomType.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoBomType.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 Id = "4567",
                 ParentName = "BOM"
@@ -46,7 +46,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacementFor = "4567",
                 ParentName = "BOM"
             };
@@ -56,7 +56,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoDecrementRule.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenReplacingWithPartWithNoDecrementRule.cs
@@ -35,7 +35,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP OLD",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacedBy = "CAP NEW",
                 Id = "4567",
                 ParentName = "BOM"
@@ -46,7 +46,7 @@
                 Type = "C",
                 Qty = 2,
                 Name = "CAP NEW",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 ReplacementFor = "4567",
                 ParentName = "BOM"
             };
@@ -56,7 +56,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(new Bom

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUndoingAReplacementMadeOnThisChangeRequest.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUndoingAReplacementMadeOnThisChangeRequest.cs
@@ -69,7 +69,7 @@
                 Name = "BOM",
                 Qty = 1,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode> { this.c1, this.c2 }
             };
 

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFields.cs
@@ -27,7 +27,7 @@
                 Name = "BOM",
                 Qty = 2,
                 Type = "A",
-                HasChanged = true,
+                AssemblyHasChanges = true,
                 Children = new List<BomTreeNode>
                                               {
                                                   new BomTreeNode
@@ -45,7 +45,7 @@
                                   DetailId = 123,
                                   Qty = 1,
                                   AddChangeId = 666,
-                                  AddChange = new BomChange {DocumentNumber = 100}
+                                  AddChange = new BomChange { DocumentNumber = 100 }
                               };
             this.BomDetailRepository.FindById(123).Returns(this.detail);
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFieldsButDetailWasAddedByDifferentCrf.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenUpdatingExistingDetailFieldsButDetailWasAddedByDifferentCrf.cs
@@ -27,7 +27,7 @@
                                Name = "BOM",
                                Qty = 2,
                                Type = "A",
-                               HasChanged = true,
+                               AssemblyHasChanges = true,
                                Children = new List<BomTreeNode> 
                                               { 
                                                   new BomTreeNode


### PR DESCRIPTION
- fixes a bug where, when adding a subassembly to a bom, an extraneous BomChange was added to the change request for that subassembly (correct behaviour is only one bom change for the bom that is actually changing is created)