### PR TITLE
ReportReturnResource example

### DIFF
--- a/src/Facade/Services/IPartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/IPartsReceivedReportFacadeService.cs
@@ -10,7 +10,7 @@
     {
         public IResult<ReportReturnResource> GetReport(PartsReceivedReportRequestResource options);
 
-        public IEnumerable<IEnumerable<string>> GetReportCsv(PartsReceivedReportRequestResource options);
+        public CsvResult<IEnumerable<IEnumerable<string>>> GetReportCsv(PartsReceivedReportRequestResource options);
     }
 }
 

--- a/src/Facade/Services/PartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/PartsReceivedReportFacadeService.cs
@@ -39,15 +39,16 @@
 
         public CsvResult<IEnumerable<IEnumerable<string>>> GetReportCsv(PartsReceivedReportRequestResource options)
         {
+            var data = this.domainService.GetReport(
+                options.Jobref,
+                options.Supplier,
+                options.FromDate,
+                options.ToDate,
+                options.OrderBy,
+                options.IncludeNegativeValues).ConvertToCsvList();
             return new CsvResult<IEnumerable<IEnumerable<string>>>("parts_received.csv")
                        {
-                           Data = this.domainService.GetReport(
-                               options.Jobref,
-                               options.Supplier,
-                               options.FromDate,
-                               options.ToDate,
-                               options.OrderBy,
-                               options.IncludeNegativeValues).ConvertToCsvList()
+                           Data = data
                        };
         }
     }

--- a/src/Facade/Services/PartsReceivedReportFacadeService.cs
+++ b/src/Facade/Services/PartsReceivedReportFacadeService.cs
@@ -37,15 +37,18 @@
             return new SuccessResult<ReportReturnResource>(resource);
         }
 
-        public IEnumerable<IEnumerable<string>> GetReportCsv(PartsReceivedReportRequestResource options)
+        public CsvResult<IEnumerable<IEnumerable<string>>> GetReportCsv(PartsReceivedReportRequestResource options)
         {
-            return this.domainService.GetReport(
-                options.Jobref,
-                options.Supplier,
-                options.FromDate,
-                options.ToDate,
-                options.OrderBy,
-                options.IncludeNegativeValues).ConvertToCsvList();
+            return new CsvResult<IEnumerable<IEnumerable<string>>>("parts_received.csv")
+                       {
+                           Data = this.domainService.GetReport(
+                               options.Jobref,
+                               options.Supplier,
+                               options.FromDate,
+                               options.ToDate,
+                               options.OrderBy,
+                               options.IncludeNegativeValues).ConvertToCsvList()
+                       };
         }
     }
 }

--- a/src/IoC/HandlerExtensions.cs
+++ b/src/IoC/HandlerExtensions.cs
@@ -101,7 +101,7 @@
                 .AddTransient<IHandler, JsonResultHandler<IEnumerable<BomHistoryReportLineResource>>>()
                 .AddTransient<IHandler, JsonResultHandler<PartDataSheetValuesResource>>()
                 .AddTransient<IHandler, JsonResultHandler<IEnumerable<PartDataSheetValuesResource>>>()
-                .AddTransient<IHandler, CsvResultHandler>();
+                .AddTransient<IHandler, CsvFileResultHandler>();
         }
     }
 }

--- a/src/Service/Modules/Reports/PartsReceivedReportModule.cs
+++ b/src/Service/Modules/Reports/PartsReceivedReportModule.cs
@@ -88,7 +88,7 @@
             
             var csv = reportFacadeService.GetReportCsv(options);
 
-            await res.FromCsv(csv, "parts_received.csv");
+            await res.Negotiate(csv);
         }
     }
 }

--- a/src/Service/ResultHandlers/CsvFileResultHandler.cs
+++ b/src/Service/ResultHandlers/CsvFileResultHandler.cs
@@ -15,7 +15,7 @@
     using Microsoft.AspNetCore.Http;
 
     // todo - move to common
-    public class CsvResultHandler : IHandler
+    public class CsvFileResultHandler : IHandler
     {
         public bool CanHandle(object model, string contentType)
         {

--- a/src/Service/ResultHandlers/CsvResultHandler.cs
+++ b/src/Service/ResultHandlers/CsvResultHandler.cs
@@ -35,9 +35,9 @@
 
             var writer = new CsvWriter(sw, CultureInfo.InvariantCulture);
 
-            if (csvResult.Data is CsvResult<IEnumerable<IEnumerable<string>>> csvGrid)
+            if (csvResult.Data is IEnumerable<IEnumerable> csvGrid)
             {
-                foreach (var line in csvGrid.Data)
+                foreach (var line in csvGrid)
                 {
                     foreach (var field in line)
                     {

--- a/src/Service/ResultHandlers/CsvResultHandler.cs
+++ b/src/Service/ResultHandlers/CsvResultHandler.cs
@@ -11,7 +11,6 @@
     using CsvHelper;
 
     using Linn.Common.Facade.Carter;
-    using Linn.Purchasing.Facade;
 
     using Microsoft.AspNetCore.Http;
 
@@ -27,9 +26,6 @@
             HttpRequest req, HttpResponse res, object model, CancellationToken cancellationToken)
         {
             dynamic csvResult = model;
-
-            res.ContentType = "text/csv; charset=utf-8";
-            res.Headers.ContentDisposition = $"attachment; filename=\"{csvResult.Title}\"";
 
             var sw = new StringWriter();
 
@@ -57,6 +53,11 @@
             }
             
             await writer.FlushAsync();
+
+            res.StatusCode = 200;
+            res.ContentType = "text/csv; charset=utf-8";
+            res.Headers.ContentDisposition = $"attachment; filename=\"{csvResult.Title}\"";
+
             await res.WriteAsync(sw.ToString(), cancellationToken: cancellationToken);
         }
     }

--- a/tests/Integration/Integration.Tests/PartsReceivedReportModuleTests/WhenGettingExport.cs
+++ b/tests/Integration/Integration.Tests/PartsReceivedReportModuleTests/WhenGettingExport.cs
@@ -68,7 +68,7 @@
         public void ShouldReturnCsvContentType()
         {
             this.Response.Content.Headers.ContentType.Should().NotBeNull();
-            this.Response.Content.Headers.ContentType?.ToString().Should().Be("text/csv");
+            this.Response.Content.Headers.ContentType?.ToString().Should().Be("text/csv; charset=utf-8");
         }
 
         [Test]


### PR DESCRIPTION
@richardiphillips here is an example of how this might work with the ReportReturnResource.ConvertToCsvList()
- you are right - it is a slight breaking change if I add this to Common (facade methods will need to return a CsvResult now)