### PR TITLE
Bom copy delete replace fixes

### DIFF
--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -99,9 +99,8 @@
                 {
                     this.bomDetailRepository.Remove(detail);
                 }
-
-                if (!detail.DeleteChangeId.HasValue && new[] { "PROPOS", "ACCEPT", "LIVE" }
-                        .Contains(detail.ChangeState))
+                else if (!detail.DeleteChangeId.HasValue && new[] { "PROPOS", "ACCEPT", "LIVE" }
+                             .Contains(detail.ChangeState))
                 {
                     detail.DeleteChangeId = change.ChangeId;
                 }

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -94,11 +94,10 @@
             foreach (var child in bom.Details)
             {
                 var detail = this.bomDetailRepository.FindById(child.DetailId);
-                if (!detail.DeleteChangeId.HasValue && new[] { "PROPOS", "ACCEPT", "LIVE" }
+                if (new[] { "PROPOS", "ACCEPT", "LIVE" }
                         .Contains(detail.ChangeState))
                 {
                     detail.DeleteChangeId = change.ChangeId;
-                    detail.ChangeState = "HIST";
                 }
             }
         }

--- a/src/Domain.LinnApps/Boms/BomChangeService.cs
+++ b/src/Domain.LinnApps/Boms/BomChangeService.cs
@@ -94,7 +94,13 @@
             foreach (var child in bom.Details)
             {
                 var detail = this.bomDetailRepository.FindById(child.DetailId);
-                if (new[] { "PROPOS", "ACCEPT", "LIVE" }
+                
+                if (detail.AddChange.DocumentNumber == crfNumber)
+                {
+                    this.bomDetailRepository.Remove(detail);
+                }
+
+                if (!detail.DeleteChangeId.HasValue && new[] { "PROPOS", "ACCEPT", "LIVE" }
                         .Contains(detail.ChangeState))
                 {
                     detail.DeleteChangeId = change.ChangeId;

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -99,6 +99,7 @@ function BomUtility() {
     const [partMessage, setPartMessage] = useState();
 
     const openPartLookUp = forRow => {
+        console.log(forRow);
         setPartMessage();
         setPartLookUp({ open: true, forRow });
         setPartSearchTerm(null);
@@ -465,6 +466,7 @@ function BomUtility() {
     const [bomToCopy, setBomToCopy] = useState();
 
     const handlePartSelect = newValue => {
+        console.log(newValue);
         if (selected.children.find(x => x.name === newValue.partNumber)) {
             setPartMessage('Part already on BOM!');
             return;
@@ -479,7 +481,17 @@ function BomUtility() {
             reduxDispatch(subAssemblyActions.fetchByHref(subAssemblyUrl));
         } else {
             if (newValue.bomType !== 'C') {
-                setNewAssemblies(n => [...n, { id: partLookUp.forRow.id, children: [] }]);
+                setNewAssemblies(n => [
+                    ...n,
+                    {
+                        id: partLookUp.forRow.id,
+                        name: newValue.partNumber,
+                        type: newValue.bomType,
+                        isNewAddition: true,
+                        children: []
+                    }
+                ]);
+                console.log(newAssemblies);
             }
             processRowUpdate({
                 ...partLookUp.forRow,
@@ -487,6 +499,7 @@ function BomUtility() {
                 safetyCritical: newValue.safetyCriticalPart,
                 drawingReference: newValue.drawingReference,
                 type: newValue.bomType,
+                isNewAddition: true,
                 description: newValue.description,
                 children: newValue.bomType === 'C' ? null : []
             });
@@ -502,6 +515,7 @@ function BomUtility() {
                     ...partLookUp.forRow,
                     name: subAssembly.name,
                     type: subAssembly.type,
+                    isNewAddition: true,
                     safetyCritical: subAssembly.safetyCritical,
                     drawingReference: subAssembly.drawingReference,
                     description: subAssembly.description,
@@ -634,6 +648,7 @@ function BomUtility() {
                         setCopyBomDialogOpen(false);
                         setPartSearchTerm(null);
                         if (copyBomDialogOpen) {
+                            console.log(selected);
                             reduxDispatch(
                                 bomTreeActions.postByHref('/purchasing/boms/copy', {
                                     srcPartNumber: bomToCopy,
@@ -921,7 +936,7 @@ function BomUtility() {
                             </Button>
                             <Button
                                 variant="outlined"
-                                disabled={!crNumber}
+                                disabled={!crNumber || selected?.isNewAddition}
                                 onClick={() => {
                                     setCopyBomDialogOpen(true);
                                     setBomToCopy(null);
@@ -970,9 +985,11 @@ function BomUtility() {
                             renderComponents={false}
                             renderQties={false}
                             onNodeSelect={id => {
-                                setSelected(
+                                setSelected(s =>
                                     [...newAssemblies, ...nodesWithChildren].find(x => x.id === id)
                                 );
+                                console.log(selected);
+
                             }}
                             bomName={bomName}
                             bomTree={treeView}

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -99,7 +99,6 @@ function BomUtility() {
     const [partMessage, setPartMessage] = useState();
 
     const openPartLookUp = forRow => {
-        console.log(forRow);
         setPartMessage();
         setPartLookUp({ open: true, forRow });
         setPartSearchTerm(null);
@@ -466,7 +465,6 @@ function BomUtility() {
     const [bomToCopy, setBomToCopy] = useState();
 
     const handlePartSelect = newValue => {
-        console.log(newValue);
         if (selected.children.find(x => x.name === newValue.partNumber)) {
             setPartMessage('Part already on BOM!');
             return;
@@ -491,7 +489,6 @@ function BomUtility() {
                         children: []
                     }
                 ]);
-                console.log(newAssemblies);
             }
             processRowUpdate({
                 ...partLookUp.forRow,
@@ -648,7 +645,6 @@ function BomUtility() {
                         setCopyBomDialogOpen(false);
                         setPartSearchTerm(null);
                         if (copyBomDialogOpen) {
-                            console.log(selected);
                             reduxDispatch(
                                 bomTreeActions.postByHref('/purchasing/boms/copy', {
                                     srcPartNumber: bomToCopy,
@@ -985,11 +981,9 @@ function BomUtility() {
                             renderComponents={false}
                             renderQties={false}
                             onNodeSelect={id => {
-                                setSelected(s =>
+                                setSelected(
                                     [...newAssemblies, ...nodesWithChildren].find(x => x.id === id)
                                 );
-                                console.log(selected);
-
                             }}
                             bomName={bomName}
                             bomTree={treeView}

--- a/src/Service.Host/client/src/components/BomUtility/BomUtility.js
+++ b/src/Service.Host/client/src/components/BomUtility/BomUtility.js
@@ -194,8 +194,8 @@ function BomUtility() {
         {
             field: 'description',
             headerName: 'Description',
-            hide: showChanges,
-            width: 250,
+            hide: false,
+            width: 350,
             editable: false,
             renderCell: params =>
                 params.row.isReplaced || params.row.toDelete ? (
@@ -247,7 +247,7 @@ function BomUtility() {
             field: 'addReplaceSeq',
             headerName: 'In',
             width: 75,
-            hide: !showChanges,
+            hide: true,
 
             editable: false
         },
@@ -271,7 +271,7 @@ function BomUtility() {
         {
             field: 'deleteReplaceSeq',
             headerName: 'Out',
-            hide: !showChanges,
+            hide: true,
             width: 75,
             editable: false
         },
@@ -849,7 +849,7 @@ function BomUtility() {
     };
 
     return (
-        <Page history={history} homeUrl={config.appRoot}>
+        <Page history={history} homeUrl={config.appRoot} width="xl">
             {PartLookUp()}
             {CopyExplodeBomDialog()}
             {DeleteAllFromBomDialog()}

--- a/src/Service.Host/client/src/hooks/useExpandNodesWithChildren.js
+++ b/src/Service.Host/client/src/hooks/useExpandNodesWithChildren.js
@@ -15,10 +15,12 @@ export default function useExpandNodesWithChildren(initial, tree, rootName) {
             while (n > 0) {
                 const current = q[0];
                 q.shift();
-                if (current.children?.length) {
+                if (current.type !== 'C') {
                     result.push(current);
-                    for (let i = 0; i < current.children.length; i += 1) {
-                        q.push(current.children[i]);
+                    if (current.children?.length) {
+                        for (let i = 0; i < current.children.length; i += 1) {
+                            q.push(current.children[i]);
+                        }
                     }
                 }
                 n -= 1;

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAllFromBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAllFromBom.cs
@@ -24,14 +24,21 @@
 
         private BomDetail detail5;
 
+        private BomDetail detail6;
+
         [SetUp]
         public void SetUp()
         {
-            this.detail1 = new BomDetail { DetailId = 1, ChangeState = "PROPOS",  };
-            this.detail2 = new BomDetail { DetailId = 2, ChangeState = "PROPOS" };
-            this.detail3 = new BomDetail { DetailId = 3, ChangeState = "PROPOS" };
-            this.detail4 = new BomDetail { DetailId = 4, ChangeState = "PROPOS", DeleteChangeId = 1 };
-            this.detail5 = new BomDetail { DetailId = 5, ChangeState = "CANCEL" };
+            this.detail1 = new BomDetail { DetailId = 1, ChangeState = "PROPOS", AddChange = new BomChange() };
+            this.detail2 = new BomDetail { DetailId = 2, ChangeState = "PROPOS", AddChange = new BomChange() };
+            this.detail3 = new BomDetail { DetailId = 3, ChangeState = "PROPOS", AddChange = new BomChange() };
+            this.detail4 = new BomDetail { DetailId = 4, ChangeState = "PROPOS", AddChange = new BomChange(), DeleteChangeId = 1 };
+            this.detail5 = new BomDetail { DetailId = 5, ChangeState = "CANCEL", AddChange = new BomChange() };
+            this.detail6 = new BomDetail
+                               {
+                                   DetailId = 6, AddChange = new BomChange { DocumentNumber = 123 }
+                               };
+
 
             this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>())
                 .Returns(new Bom
@@ -43,7 +50,8 @@
                                                     new BomDetailViewEntry { DetailId = 2 },
                                                     new BomDetailViewEntry { DetailId = 3 },
                                                     new BomDetailViewEntry { DetailId = 4 },
-                                                    new BomDetailViewEntry { DetailId = 5 }
+                                                    new BomDetailViewEntry { DetailId = 5 },
+                                                    new BomDetailViewEntry { DetailId = 6 }
                                                }
                 });
             this.BomDetailRepository.FindById(1).Returns(this.detail1);
@@ -51,16 +59,18 @@
             this.BomDetailRepository.FindById(3).Returns(this.detail3);
             this.BomDetailRepository.FindById(4).Returns(this.detail4);
             this.BomDetailRepository.FindById(5).Returns(this.detail5);
-            this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(123);
+            this.BomDetailRepository.FindById(6).Returns(this.detail6);
+
+            this.DatabaseService.GetIdSequence("CHG_SEQ").Returns(999);
             this.Sut.DeleteAllFromBom("BOM", 123, 33087);
         }
 
         [Test]
-        public void ShouldUpdateNonCancelledNonDeletedDetails()
+        public void ShouldUpdateNonCancelledNonDeletedDetailsNotAddedByThisChangeRequest()
         {
-            this.detail1.DeleteChangeId.Should().Be(123);
-            this.detail2.DeleteChangeId.Should().Be(123);
-            this.detail3.DeleteChangeId.Should().Be(123);
+            this.detail1.DeleteChangeId.Should().Be(999);
+            this.detail2.DeleteChangeId.Should().Be(999);
+            this.detail3.DeleteChangeId.Should().Be(999);
         }
 
         [Test]
@@ -68,6 +78,13 @@
         {
             this.detail4.DeleteChangeId.Should().Be(1);
             this.detail5.DeleteChangeId.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldDeleteDetailsAddedByThisChangeRequest()
+        {
+            this.BomDetailRepository.Received()
+                .Remove(Arg.Is<BomDetail>(d => d.DetailId == this.detail6.DetailId));
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAllFromBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/BomChangeServiceTests/WhenDeletingAllFromBom.cs
@@ -59,11 +59,8 @@
         public void ShouldUpdateNonCancelledNonDeletedDetails()
         {
             this.detail1.DeleteChangeId.Should().Be(123);
-            this.detail1.ChangeState.Should().Be("HIST");
             this.detail2.DeleteChangeId.Should().Be(123);
-            this.detail1.ChangeState.Should().Be("HIST");
             this.detail3.DeleteChangeId.Should().Be(123);
-            this.detail1.ChangeState.Should().Be("HIST");
         }
 
         [Test]


### PR DESCRIPTION
 - nuke a bom detail if user is doing the 'Delete All' process and said detail was added by the current CRF (since it never made it onto the bom)
 - don't allow copying onto assembliesthat haven't been 'Saved' onto the bom yet
 - ui tweaks