### PR TITLE
Support odds and ends

### DIFF
--- a/src/Domain.LinnApps/Mailers/PurchaseOrderRemindersMailer.cs
+++ b/src/Domain.LinnApps/Mailers/PurchaseOrderRemindersMailer.cs
@@ -69,7 +69,7 @@
             body += "Linn Products Ltd";
 
             this.emailService.SendEmail(
-                toAddress, 
+                toAddress.Trim(), 
                 supplier.Name, 
                 null, 
                 null, 

--- a/src/Service.Host/client/src/components/__tests__/boards/Board.test.js
+++ b/src/Service.Host/client/src/components/__tests__/boards/Board.test.js
@@ -112,10 +112,25 @@ describe('When editing...', () => {
         render(<Board />);
     });
     test('Shoud update values on save...', async () => {
-        const input = screen.getByLabelText('Description');
+        let input = screen.getByLabelText('Description');
         fireEvent.change(input, { target: { value: 'New description of 0123' } });
 
         const saveButton = await screen.findByRole('button', { name: 'Save' });
+
+        let tab = screen.getByText('Layouts');
+        fireEvent.click(tab);
+
+        let button = await screen.findByRole('button', { name: 'New Layout' });
+        fireEvent.click(button);
+
+        tab = screen.getByText('Revisions');
+        fireEvent.click(tab);
+
+        button = await screen.findByRole('button', { name: 'New Revision' });
+        fireEvent.click(button);
+
+        input = screen.getByLabelText('PCB Part Number');
+        fireEvent.change(input, { target: { value: 'Test' } });
         fireEvent.click(saveButton);
 
         expect(updateSpy).toHaveBeenCalledTimes(1);
@@ -146,6 +161,22 @@ describe('When creating...', () => {
         fireEvent.change(input, { target: { value: '456' } });
 
         const saveButton = await screen.findByRole('button', { name: 'Save' });
+
+        let tab = screen.getByText('Layouts');
+        fireEvent.click(tab);
+
+        let button = await screen.findByRole('button', { name: 'New Layout' });
+        fireEvent.click(button);
+
+        tab = screen.getByText('Revisions');
+        fireEvent.click(tab);
+
+        button = await screen.findByRole('button', { name: 'New Revision' });
+        fireEvent.click(button);
+
+        input = screen.getByLabelText('PCB Part Number');
+        fireEvent.change(input, { target: { value: 'Test' } });
+
         fireEvent.click(saveButton);
 
         expect(addSpy).toHaveBeenCalledTimes(1);

--- a/src/Service.Host/client/src/components/boards/Board.js
+++ b/src/Service.Host/client/src/components/boards/Board.js
@@ -53,6 +53,15 @@ function Board({ creating }) {
     const [state, dispatch] = useReducer(boardReducer, { board: null });
     const itemError = useSelector(reduxState => getItemError(reduxState, 'board'));
 
+    const layout =
+        state.board.layouts && state.selectedLayout?.length
+            ? state.board.layouts.find(a => a.layoutCode === state.selectedLayout[0])
+            : null;
+    const revision =
+        layout && state.selectedRevision?.length && layout.revisions && layout.revisions.length
+            ? layout.revisions.find(a => a.revisionCode === state.selectedRevision[0])
+            : null;
+
     useEffect(() => {
         if (creating) {
             reduxDispatch(boardActions.clearItem());
@@ -158,6 +167,7 @@ function Board({ creating }) {
         state.board.description &&
         state.board.splitBom &&
         state.board.boardCode &&
+        revision.pcbPartNumber &&
         layoutsAreOk(state.board.layouts) &&
         revisionsAreOk(state.board.layouts);
 

--- a/src/Service.Host/client/src/components/boards/Board.js
+++ b/src/Service.Host/client/src/components/boards/Board.js
@@ -54,7 +54,7 @@ function Board({ creating }) {
     const itemError = useSelector(reduxState => getItemError(reduxState, 'board'));
 
     const layout =
-        state.board.layouts && state.selectedLayout?.length
+        state.board?.layouts && state.selectedLayout?.length
             ? state.board.layouts.find(a => a.layoutCode === state.selectedLayout[0])
             : null;
     const revision =
@@ -167,7 +167,6 @@ function Board({ creating }) {
         state.board.description &&
         state.board.splitBom &&
         state.board.boardCode &&
-        revision.pcbPartNumber &&
         layoutsAreOk(state.board.layouts) &&
         revisionsAreOk(state.board.layouts);
 
@@ -290,7 +289,9 @@ function Board({ creating }) {
                     )}
                     <Grid item xs={12}>
                         <SaveBackCancelButtons
-                            saveDisabled={!okToSave() || editStatus === 'view'}
+                            saveDisabled={
+                                !okToSave() || !revision?.pcbPartNumber || editStatus === 'view'
+                            }
                             saveClick={saveBoard}
                             cancelClick={handleCancel}
                             backClick={() => history.push('/purchasing/boms/boards')}

--- a/src/Service.Host/client/src/components/boards/Board.js
+++ b/src/Service.Host/client/src/components/boards/Board.js
@@ -267,6 +267,7 @@ function Board({ creating }) {
                         {selectedTab === 2 && (
                             <RevisionTab
                                 layouts={state.board.layouts}
+                                revision={revision}
                                 style={{ paddingTop: '40px' }}
                                 dispatch={dispatch}
                                 selectedLayout={state.selectedLayout}

--- a/src/Service.Host/client/src/components/boards/BoardTab.js
+++ b/src/Service.Host/client/src/components/boards/BoardTab.js
@@ -136,7 +136,7 @@ BoardTab.defaultProps = {
     idBoard: null,
     defaultPcbNumber: null,
     variantOfBoardCode: null,
-    splitBom: 'N',
+    splitBom: 'Y',
     creating: false
 };
 

--- a/src/Service.Host/client/src/components/boards/BoardTab.js
+++ b/src/Service.Host/client/src/components/boards/BoardTab.js
@@ -136,7 +136,7 @@ BoardTab.defaultProps = {
     idBoard: null,
     defaultPcbNumber: null,
     variantOfBoardCode: null,
-    splitBom: null,
+    splitBom: 'N',
     creating: false
 };
 

--- a/src/Service.Host/client/src/components/boards/RevisionTab.js
+++ b/src/Service.Host/client/src/components/boards/RevisionTab.js
@@ -87,7 +87,7 @@ function RevisionTab({
                             <Grid item xs={8} />
                             <Grid item xs={3}>
                                 <Dropdown
-                                    value={revision.splitBom ?? 'No'}
+                                    value={revision.splitBom ?? 'Y'}
                                     label="Split Bom"
                                     propertyName="splitBom"
                                     items={[

--- a/src/Service.Host/client/src/components/boards/RevisionTab.js
+++ b/src/Service.Host/client/src/components/boards/RevisionTab.js
@@ -15,7 +15,8 @@ function RevisionTab({
     searchParts,
     partsSearchResults,
     partsSearchLoading,
-    editingAllowed
+    editingAllowed,
+    revision
 }) {
     const columns = [{ field: 'revisionCode', headerName: 'Revision', width: 175 }];
     const rows =
@@ -26,15 +27,6 @@ function RevisionTab({
                   .find(a => a.layoutCode === selectedLayout[0])
                   .revisions.map(l => ({ ...l, id: l.revisionCode }))
             : [];
-
-    const layout =
-        layouts && selectedLayout?.length
-            ? layouts.find(a => a.layoutCode === selectedLayout[0])
-            : null;
-    const revision =
-        layout && selectedRevision?.length && layout.revisions && layout.revisions.length
-            ? layout.revisions.find(a => a.revisionCode === selectedRevision[0])
-            : null;
     const handleRevisionChange = (propertyName, newValue) => {
         if (editingAllowed) {
             setEditStatus('edit');
@@ -192,7 +184,16 @@ RevisionTab.propTypes = {
     partsSearchResults: PropTypes.arrayOf(PropTypes.shape({})),
     partsSearchLoading: PropTypes.bool,
     searchParts: PropTypes.func.isRequired,
-    editingAllowed: PropTypes.string
+    editingAllowed: PropTypes.string,
+    revision: PropTypes.shape({
+        pcbPartNumber: PropTypes.string,
+        pcasPartNumber: PropTypes.string,
+        creating: PropTypes.bool,
+        pcsmPartNumber: PropTypes.string,
+        revisionCode: PropTypes.string,
+        splitBom: PropTypes.string,
+        revisionNumber: PropTypes.string
+    })
 };
 
 RevisionTab.defaultProps = {
@@ -200,7 +201,8 @@ RevisionTab.defaultProps = {
     selectedRevision: [],
     partsSearchResults: [],
     partsSearchLoading: false,
-    editingAllowed: null
+    editingAllowed: null,
+    revision: null
 };
 
 export default RevisionTab;

--- a/src/Service.Host/client/src/components/boards/RevisionTab.js
+++ b/src/Service.Host/client/src/components/boards/RevisionTab.js
@@ -95,7 +95,7 @@ function RevisionTab({
                             <Grid item xs={8} />
                             <Grid item xs={3}>
                                 <Dropdown
-                                    value={revision.splitBom}
+                                    value={revision.splitBom ?? 'No'}
                                     label="Split Bom"
                                     propertyName="splitBom"
                                     items={[

--- a/src/Service.Host/views/PurchaseOrder.cshtml
+++ b/src/Service.Host/views/PurchaseOrder.cshtml
@@ -403,7 +403,7 @@
                 All invoices and delivery notes must always quote the above order numbers.
                 All prices on orders are exclusive of value added tax.
                 For conditions of purchase see below.
-                Please confirm all deliveries on this purchase order within 48 hours to acknowledgements@linn.co.uk
+                Please confirm all deliveries on this purchase order within 48 hours via reply to the sender of this order.
                 </pre>
         </div>
     </div>


### PR DESCRIPTION
- use trim() stop whitespaces at start of supplier contacts email address busting the po reminder emails 
- default some dropdowns to No on the Boards Ut
- stop create or update of board with no PCB Part Number on the revision, at jackis request
- remove redundant email address from PO pdfs