### PR TITLE
fix bug that was stopping individual changes on a crf being made live

### DIFF
--- a/tests/Integration/Integration.Tests/ChangeRequestModuleTests/ContextBase.cs
+++ b/tests/Integration/Integration.Tests/ChangeRequestModuleTests/ContextBase.cs
@@ -49,7 +49,7 @@
 
         protected IRepository<CircuitBoard, string> BoardRepository { get; set; }
 
-        protected IRepository<Bom, int> BomRepository { get; set; }
+        protected IRepository<BomDetail, int> BomDetailRepository { get; set; }
 
         protected IBomTreeService BomTreeService { get; private set; }
 
@@ -83,7 +83,7 @@
             this.BomChangeService = Substitute.For<IBomChangeService>();
             this.PcasChangeCompView = Substitute.For<IQueryRepository<PcasChangeComponent>>();
             this.PcasChangeComponentsService = new PcasChangeComponentsService(this.PcasChangeCompView);
-            this.BomRepository = Substitute.For<IRepository<Bom, int>>();
+            this.BomDetailRepository = Substitute.For<IRepository<BomDetail, int>>();
             this.FacadeService = new ChangeRequestFacadeService(
                 this.Repository,
                 this.TransactionManager,
@@ -99,7 +99,7 @@
                     this.PcasPack,
                     this.BomChangeService,
                     this.BoardRepository,
-                    this.BomRepository),
+                    this.BomDetailRepository),
                     this.DatabaseService,
                     this.BomTreeService,
                     this.Logger);

--- a/tests/Unit/Domain.LinnApps.Tests/ChangeRequestServiceTests/ContextBase.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ChangeRequestServiceTests/ContextBase.cs
@@ -31,7 +31,7 @@
 
         protected IBomChangeService BomChangeService { get; private set; }
 
-        protected IRepository<Bom, int> BomRepository { get; private set; }
+        protected IRepository<BomDetail, int> BomDetailRepository { get; private set; }
 
         [SetUp]
         public void SetUpContext()
@@ -42,7 +42,7 @@
             this.EmployeeRepository = Substitute.For<IRepository<Employee, int>>();
             this.WeekRepository = Substitute.For<IRepository<LinnWeek, int>>();
             this.BoardRepository = Substitute.For<IRepository<CircuitBoard, string>>();
-            this.BomRepository = Substitute.For<IRepository<Bom, int>>();
+            this.BomDetailRepository = Substitute.For<IRepository<BomDetail, int>>();
             this.BomPack = Substitute.For<IBomPack>();
             this.PcasPack = Substitute.For<IPcasPack>();
             this.BomChangeService = Substitute.For<IBomChangeService>();
@@ -56,7 +56,7 @@
                 this.PcasPack,
                 this.BomChangeService,
                 this.BoardRepository,
-                this.BomRepository);
+                this.BomDetailRepository);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/ChangeRequestServiceTests/WhenMakingLiveWouldResultInDuplicateDetails.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ChangeRequestServiceTests/WhenMakingLiveWouldResultInDuplicateDetails.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Linq.Expressions;
 
     using FluentAssertions;
@@ -48,14 +49,11 @@
                 .HasPermissionFor(AuthorisedAction.MakeLiveChangeRequest, Arg.Any<IEnumerable<string>>())
                 .Returns(true);
 
-            this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
-                new Bom 
-                    { 
-                        Details = new List<BomDetailViewEntry>
+            this.BomDetailRepository.FilterBy(Arg.Any<Expression<Func<BomDetail, bool>>>()).Returns(
+                 new List<BomDetail>
                                         {
-                                            new BomDetailViewEntry { PartNumber = "PACK 117", ChangeState = "LIVE" }
-                                        }
-                    });
+                                            new BomDetail { PartNumber = "PACK 117", ChangeState = "LIVE" }
+                                        }.AsQueryable());
 
             this.action = () => this.Sut.MakeLive(1, 7, null, null, new List<string>());
         }

--- a/tests/Unit/Domain.LinnApps.Tests/ChangeRequestServiceTests/WhenMakingLiveWouldResultInNonLivePartOnLivePartBom.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/ChangeRequestServiceTests/WhenMakingLiveWouldResultInNonLivePartOnLivePartBom.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Linq.Expressions;
 
     using FluentAssertions;
@@ -54,11 +55,9 @@
                 .HasPermissionFor(AuthorisedAction.MakeLiveChangeRequest, Arg.Any<IEnumerable<string>>())
                 .Returns(true);
 
-            this.BomRepository.FindBy(Arg.Any<Expression<Func<Bom, bool>>>()).Returns(
-                new Bom
-                {
-                    Details = new List<BomDetailViewEntry>()
-                });
+            this.BomDetailRepository.FilterBy(Arg.Any<Expression<Func<BomDetail, bool>>>()).Returns(
+               new List<BomDetail>().AsQueryable());
+
             this.PartRepository.FindBy(Arg.Any<Expression<Func<Part, bool>>>()).Returns(
                 new Part { PartNumber = "NEW PRODUCT 8", DateLive = 28.March(2023) });
             this.action = () => this.Sut.MakeLive(1, 7, null, null, new List<string>());

--- a/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/ContextBase.cs
+++ b/tests/Unit/Facade.Tests/ChangeRequestFacadeServiceTests/ContextBase.cs
@@ -45,7 +45,7 @@
 
         protected ChangeRequestFacadeService Sut { get; private set; }
 
-        protected IRepository<Bom, int> BomRepository { get; private set; }
+        protected IRepository<BomDetail, int> BomDetailRepository { get; private set; }
 
         [SetUp]
         public void SetUpContext()
@@ -62,7 +62,7 @@
             this.BomPack = Substitute.For<IBomPack>();
             this.PcasPack = Substitute.For<IPcasPack>();
             this.BomChangeService = Substitute.For<IBomChangeService>();
-            this.BomRepository = Substitute.For<IRepository<Bom, int>>();
+            this.BomDetailRepository = Substitute.For<IRepository<BomDetail, int>>();
             this.Logger = Substitute.For<ILog>();
 
             this.Sut = new ChangeRequestFacadeService(
@@ -82,7 +82,7 @@
                 this.PcasPack,
                 this.BomChangeService,
                 this.BoardRepository,
-                this.BomRepository),
+                this.BomDetailRepository),
                 this.DatabaseService, 
                 this.BomTreeService,
                 this.Logger);


### PR DESCRIPTION
- I didn't realise you could make selected changes live without making the whole crf live
- so needed to make sure any new live / nonlive checks I had added were only applied to specific selected changeIds where appropriate, and not just the whole CRF (since sometimes individual changes on the CRF are valid to be made LIVE when the whole thing isn't