### PR TITLE
BaseOurUnitPrice decimal places

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderDeliveryService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderDeliveryService.cs
@@ -249,7 +249,7 @@
                         this.purchaseOrdersPack.GetVatAmountSupplier(
                             detail.BaseOurUnitPrice.GetValueOrDefault() * update.Qty,
                             existingDelivery.PurchaseOrderDetail.PurchaseOrder.SupplierId),
-                        2);
+                        5);
                     updatedDeliveries.Add(new PurchaseOrderDelivery
                     {
                         OrderNumber = group.OrderNumber,
@@ -269,10 +269,10 @@
                         BaseDeliveryTotal = Math.Round(
                                                       (update.Qty * detail.BaseOurUnitPrice.GetValueOrDefault())
                                                     + baseVatAmount,
-                                                      2),
+                                                      5),
                         BaseNetTotal = Math.Round(
                                                       update.Qty * detail.BaseOurUnitPrice.GetValueOrDefault(),
-                                                      2),
+                                                      5),
                         OrderDeliveryQty = update.Qty / detail.OrderConversionFactor,
                         BaseOrderUnitPrice = existingDelivery.BaseOrderUnitPrice,
                         VatTotalCurrency = vatAmount,
@@ -442,7 +442,7 @@
                         this.purchaseOrdersPack.GetVatAmountSupplier(
                             detail.BaseOurUnitPrice.GetValueOrDefault() * del.OurDeliveryQty.GetValueOrDefault(),
                             order.SupplierId),
-                        2);
+                        5);
                     var reason = del.DateAdvised.HasValue ? "ADVISED" : "REQUESTED";
 
                     // update the existing record if it exists
@@ -482,12 +482,12 @@
                         existing.BaseOrderUnitPrice = detail.BaseOrderUnitPrice;
                         existing.BaseNetTotal = Math.Round(
                             del.OurDeliveryQty.GetValueOrDefault() * detail.BaseOurUnitPrice.GetValueOrDefault(),
-                            2);
+                            5);
                         existing.BaseVatTotal = baseVatAmount;
                         existing.BaseDeliveryTotal = Math.Round(
                             (del.OurDeliveryQty.GetValueOrDefault() * detail.BaseOurUnitPrice.GetValueOrDefault())
                             + baseVatAmount,
-                            2);
+                            5);
                         existing.RescheduleReason = reason;
                         existing.AvailableAtSupplier = del.AvailableAtSupplier;
                         return existing;
@@ -523,13 +523,13 @@
                         BaseNetTotal = Math.Round(
                                              del.OurDeliveryQty.GetValueOrDefault()
                                              * detail.BaseOurUnitPrice.GetValueOrDefault(),
-                                             2),
+                                             5),
                         BaseVatTotal = baseVatAmount,
                         BaseDeliveryTotal = Math.Round(
                                                  (del.OurDeliveryQty.GetValueOrDefault()
                                                   * detail.BaseOurUnitPrice.GetValueOrDefault())
                                                  + baseVatAmount,
-                                                 2),
+                                                 5),
                         QuantityOutstanding = del.OurDeliveryQty,
                         QtyNetReceived = 0,
                         QtyPassedForPayment = 0,

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderDeliveryService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderDeliveryService.cs
@@ -249,7 +249,7 @@
                         this.purchaseOrdersPack.GetVatAmountSupplier(
                             detail.BaseOurUnitPrice.GetValueOrDefault() * update.Qty,
                             existingDelivery.PurchaseOrderDetail.PurchaseOrder.SupplierId),
-                        5);
+                        2);
                     updatedDeliveries.Add(new PurchaseOrderDelivery
                     {
                         OrderNumber = group.OrderNumber,
@@ -269,10 +269,10 @@
                         BaseDeliveryTotal = Math.Round(
                                                       (update.Qty * detail.BaseOurUnitPrice.GetValueOrDefault())
                                                     + baseVatAmount,
-                                                      5),
+                                                      2),
                         BaseNetTotal = Math.Round(
                                                       update.Qty * detail.BaseOurUnitPrice.GetValueOrDefault(),
-                                                      5),
+                                                      2),
                         OrderDeliveryQty = update.Qty / detail.OrderConversionFactor,
                         BaseOrderUnitPrice = existingDelivery.BaseOrderUnitPrice,
                         VatTotalCurrency = vatAmount,
@@ -442,7 +442,7 @@
                         this.purchaseOrdersPack.GetVatAmountSupplier(
                             detail.BaseOurUnitPrice.GetValueOrDefault() * del.OurDeliveryQty.GetValueOrDefault(),
                             order.SupplierId),
-                        5);
+                        2);
                     var reason = del.DateAdvised.HasValue ? "ADVISED" : "REQUESTED";
 
                     // update the existing record if it exists
@@ -482,12 +482,12 @@
                         existing.BaseOrderUnitPrice = detail.BaseOrderUnitPrice;
                         existing.BaseNetTotal = Math.Round(
                             del.OurDeliveryQty.GetValueOrDefault() * detail.BaseOurUnitPrice.GetValueOrDefault(),
-                            5);
+                            2);
                         existing.BaseVatTotal = baseVatAmount;
                         existing.BaseDeliveryTotal = Math.Round(
                             (del.OurDeliveryQty.GetValueOrDefault() * detail.BaseOurUnitPrice.GetValueOrDefault())
                             + baseVatAmount,
-                            5);
+                            2);
                         existing.RescheduleReason = reason;
                         existing.AvailableAtSupplier = del.AvailableAtSupplier;
                         return existing;
@@ -523,13 +523,13 @@
                         BaseNetTotal = Math.Round(
                                              del.OurDeliveryQty.GetValueOrDefault()
                                              * detail.BaseOurUnitPrice.GetValueOrDefault(),
-                                             5),
+                                             2),
                         BaseVatTotal = baseVatAmount,
                         BaseDeliveryTotal = Math.Round(
                                                  (del.OurDeliveryQty.GetValueOrDefault()
                                                   * detail.BaseOurUnitPrice.GetValueOrDefault())
                                                  + baseVatAmount,
-                                                 5),
+                                                 2),
                         QuantityOutstanding = del.OurDeliveryQty,
                         QtyNetReceived = 0,
                         QtyPassedForPayment = 0,

--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrderService.cs
@@ -1110,11 +1110,11 @@
             current.BaseNetTotal = Math.Round(netTotal / exchangeRate, 2, MidpointRounding.AwayFromZero);
             current.BaseOrderUnitPrice = Math.Round(
                 current.OrderUnitPriceCurrency.GetValueOrDefault() / exchangeRate,
-                2,
+                5,
                 MidpointRounding.AwayFromZero);
             current.BaseOurUnitPrice = Math.Round(
                 current.OurUnitPriceCurrency.GetValueOrDefault() / exchangeRate,
-                2,
+                5,
                 MidpointRounding.AwayFromZero);
 
             current.BaseVatTotal = Math.Round(

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingPurchaseOrder.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenCreatingPurchaseOrder.cs
@@ -178,7 +178,7 @@
             // updated based on conv factor
             firstDetail.OrderUnitPriceCurrency.Should().Be(200.22m);
 
-            firstDetail.BaseOurUnitPrice.Should().Be(250.28m);
+            firstDetail.BaseOurUnitPrice.Should().Be(250.275m);
 
             // our qty * our unit price
             firstDetail.NetTotalCurrency.Should().Be(19821.78m);

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderConvValueQtyFields.cs
@@ -415,7 +415,7 @@
             //updated based on conv factor
             firstDetail.OrderUnitPriceCurrency.Should().Be(400.44m);
 
-            firstDetail.BaseOurUnitPrice.Should().Be(250.28m);
+            firstDetail.BaseOurUnitPrice.Should().Be(250.275m);
 
             // our qty * our unit price
             firstDetail.NetTotalCurrency.Should().Be(19821.78m);
@@ -493,13 +493,13 @@
             delivery.DeliveryTotalCurrency.Should().Be(440.99m);
 
             // base our unit price, base order unit price
-            delivery.BaseOurUnitPrice.Should().Be(250.28m);
+            delivery.BaseOurUnitPrice.Should().Be(250.275m);
             delivery.BaseOrderUnitPrice.Should().Be(500.55m);
 
             // (our delivery qty (2) * base our unit price) + base vat total  = base delivery total
-            delivery.BaseNetTotal.Should().Be(500.56m);
+            delivery.BaseNetTotal.Should().Be(500.55m);
             delivery.BaseVatTotal.Should().Be(50.69m);
-            delivery.BaseDeliveryTotal.Should().Be(551.25m);
+            delivery.BaseDeliveryTotal.Should().Be(551.24m);
         }
        
         [Test]
@@ -524,13 +524,13 @@
             delivery.DeliveryTotalCurrency.Should().Be(5046.05m);
 
             // base our unit price, base order unit price
-            delivery.BaseOurUnitPrice.Should().Be(250.28m);
+            delivery.BaseOurUnitPrice.Should().Be(250.275m);
             delivery.BaseOrderUnitPrice.Should().Be(500.55m);
 
             // (our delivery qty (25) * base our unit price) + base vat total  = base delivery total
-            delivery.BaseNetTotal.Should().Be(6257.00m);
+            delivery.BaseNetTotal.Should().Be(6256.88m);
             delivery.BaseVatTotal.Should().Be(50.69m);
-            delivery.BaseDeliveryTotal.Should().Be(6307.69m);
+            delivery.BaseDeliveryTotal.Should().Be(6307.56m);
         }
     }
 }

--- a/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderOverrideValueQtyFields.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/PurchaseOrderServiceTests/WhenUpdatingPurchaseOrderOverrideValueQtyFields.cs
@@ -411,7 +411,7 @@
             firstDetail.OrderUnitPriceCurrency.Should().Be(200m);
 
             firstDetail.OurUnitPriceCurrency.Should().Be(200.22m);
-            firstDetail.BaseOurUnitPrice.Should().Be(250.28m);
+            firstDetail.BaseOurUnitPrice.Should().Be(250.275m);
 
             // our qty * our unit price
             firstDetail.NetTotalCurrency.Should().Be(19821.78m);
@@ -488,13 +488,13 @@
             delivery.DeliveryTotalCurrency.Should().Be(1041.65m);
 
             // base our unit price, base order unit price
-            delivery.BaseOurUnitPrice.Should().Be(250.28m);
+            delivery.BaseOurUnitPrice.Should().Be(250.275m);
             delivery.BaseOrderUnitPrice.Should().Be(250m);
 
             // (our delivery qty (5) * base our unit price) + base vat total  = base delivery total
-            delivery.BaseNetTotal.Should().Be(1251.40m);
+            delivery.BaseNetTotal.Should().Be(1251.38m);
             delivery.BaseVatTotal.Should().Be(50.69m);
-            delivery.BaseDeliveryTotal.Should().Be(1302.09m);
+            delivery.BaseDeliveryTotal.Should().Be(1302.06m);
         }
 
         [Test]
@@ -519,13 +519,13 @@
             delivery.DeliveryTotalCurrency.Should().Be(5046.05m);
 
             // base our unit price, base order unit price
-            delivery.BaseOurUnitPrice.Should().Be(250.28m);
+            delivery.BaseOurUnitPrice.Should().Be(250.275m);
             delivery.BaseOrderUnitPrice.Should().Be(250m);
 
             // (our delivery qty (25) * base our unit price) + base vat total  = base delivery total
-            delivery.BaseNetTotal.Should().Be(6257.00m);
+            delivery.BaseNetTotal.Should().Be(6256.88m);
             delivery.BaseVatTotal.Should().Be(50.69m);
-            delivery.BaseDeliveryTotal.Should().Be(6307.69m);
+            delivery.BaseDeliveryTotal.Should().Be(6307.56m);
         }
     }
 }


### PR DESCRIPTION
Updated everywhere we are using the BaseOurUnitPrice to get a total to be 5 decimal places instead of 2 - please check these are all necessary. 