### PR TITLE
improve situation where authorising po req apparently does nothing ticket 18928 

### DIFF
--- a/src/Domain.LinnApps/Reports/OutstandingPoReqsReportService.cs
+++ b/src/Domain.LinnApps/Reports/OutstandingPoReqsReportService.cs
@@ -95,7 +95,7 @@
                         {
                             RowId = rowId,
                             ColumnId = "Description",
-                            TextDisplay = datum.Description.Length > 199 
+                            TextDisplay = datum.Description?.Length > 199 
                                               ? datum.Description.Substring(0, 200) : datum.Description
                         });
                 values.Add(

--- a/src/Service.Host/client/src/components/POReqs/POReqUtility.js
+++ b/src/Service.Host/client/src/components/POReqs/POReqUtility.js
@@ -289,7 +289,8 @@ function POReqUtility({ creating }) {
 
     const allowedToCancel = () => !creating && req.links?.some(l => l.rel === 'cancel');
     const allowedToAuthorise = () => !creating && req.state === 'AUTHORISE WAIT';
-    const allowedTo2ndAuthorise = () => !creating && req.state === 'AUTHORISE 2ND WAIT';
+    const allowedTo2ndAuthorise = () =>
+        !creating && req.state === 'AUTHORISE WAIT' && req.authorisedBy;
     const userHasFinancePower = () => req.links?.some(l => l.rel === 'finance-check');
     const allowedToFinanceCheck = () =>
         !creating && userHasFinancePower && req.state === 'FINANCE WAIT';


### PR DESCRIPTION
really should return a descriptive message of what's happening but at least displaying the 2nd auth gives a clue for now. 