### PR TITLE
returns order debit note link

### DIFF
--- a/src/Domain.LinnApps/PurchaseOrders/PurchaseOrder.cs
+++ b/src/Domain.LinnApps/PurchaseOrders/PurchaseOrder.cs
@@ -98,5 +98,7 @@
         public decimal BaseOrderTotal { get; set; }
 
         public IEnumerable<PurchaseLedger> LedgerEntries { get; set; }
+
+        public IEnumerable<PlCreditDebitNote> ReturnsCreditDebitNotes { get; set; }
     }
 }

--- a/src/Facade/ResourceBuilders/PurchaseOrderResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/PurchaseOrderResourceBuilder.cs
@@ -218,7 +218,7 @@
                                      };
                 }
 
-                if (model.DocumentType?.Name == "RO" && model.ReturnsCreditDebitNotes.Any())
+                if (model.DocumentType?.Name == "RO" && model.ReturnsCreditDebitNotes != null && model.ReturnsCreditDebitNotes.Any())
                 {
                     yield return new LinkResource
                     {

--- a/src/Facade/ResourceBuilders/PurchaseOrderResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/PurchaseOrderResourceBuilder.cs
@@ -217,6 +217,15 @@
                                          Href = $"{this.GetLocation(model)}"
                                      };
                 }
+
+                if (model.DocumentType?.Name == "RO" && model.ReturnsCreditDebitNotes.Any())
+                {
+                    yield return new LinkResource
+                    {
+                        Rel = "ret-credit-debit-note",
+                        Href = $"/purchasing/pl-credit-debit-notes/{model.ReturnsCreditDebitNotes.First().NoteNumber}"
+                    };
+                }
             }
         }
     }

--- a/src/Persistence.LinnApps/Repositories/PurchaseOrderRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/PurchaseOrderRepository.cs
@@ -68,6 +68,7 @@
                 .Include(p => p.OrderAddress).ThenInclude(x => x.Country)
                 .Include(o => o.Details).ThenInclude(d => d.DeliveryConfirmedBy)
                 .Include(o => o.LedgerEntries)
+                .Include(o => o.ReturnsCreditDebitNotes)
                 .First(o => o.OrderNumber == key);
         }
 

--- a/src/Persistence.LinnApps/ServiceDbContext.cs
+++ b/src/Persistence.LinnApps/ServiceDbContext.cs
@@ -778,6 +778,7 @@
             entity.Property(o => o.BaseOrderTotal).HasColumnName("BASE_ORDER_TOTAL").HasMaxLength(18);
             entity.Property(o => o.BaseOrderVatTotal).HasColumnName("BASE_ORDER_VAT_TOTAL").HasMaxLength(18);
             entity.HasMany(o => o.LedgerEntries).WithOne().HasForeignKey(l => l.OrderNumber);
+            entity.HasMany(o => o.ReturnsCreditDebitNotes).WithOne().HasForeignKey(l => l.ReturnsOrderNumber);
         }
 
         private void BuildPurchaseOrderDetails(ModelBuilder builder)


### PR DESCRIPTION
RETSU defaults the debit note according to the returns order based on the RETURNS_ORDER_NUMBER field of the debit notes.

This change to purchasing logic is just to support that
Annoyingly there is also a link between debit notes and the original purchase order which is why the link rel is ret-credit-debit-note not credit-debit-note