### PR TITLE
extend spend by supplier report to include FY before last

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 dist: focal
 sudo: required
 mono: none
-dotnet: 7.0
+dotnet: 9.0
 services: docker
 before_install: 
  - chmod +x ./scripts/*.sh

--- a/src/Domain.LinnApps/Domain.LinnApps.csproj
+++ b/src/Domain.LinnApps/Domain.LinnApps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Domain.LinnApps</AssemblyName>
     <RootNamespace>Linn.Purchasing.Domain.LinnApps</RootNamespace>
   </PropertyGroup>

--- a/src/Domain.LinnApps/Reports/Models/SupplierSpendWithTotals.cs
+++ b/src/Domain.LinnApps/Reports/Models/SupplierSpendWithTotals.cs
@@ -6,6 +6,8 @@
 
         public decimal PrevYearTotal { get; set; }
 
+        public decimal YearBeforePrevYearTotal { get; set; }
+
         public decimal YearTotal { get; set; }
 
         public decimal DateRangeTotal { get; set; }

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Domain</AssemblyName>
     <RootNamespace>Linn.Purchasing.Domain</RootNamespace>
   </PropertyGroup>

--- a/src/Facade/Facade.csproj
+++ b/src/Facade/Facade.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Facade</AssemblyName>
     <RootNamespace>Linn.Purchasing.Facade</RootNamespace>
   </PropertyGroup>

--- a/src/IoC/IoC.csproj
+++ b/src/IoC/IoC.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.IoC</AssemblyName>
     <RootNamespace>Linn.Purchasing.IoC</RootNamespace>
   </PropertyGroup>

--- a/src/Messaging.Host/Dockerfile
+++ b/src/Messaging.Host/Dockerfile
@@ -1,4 +1,4 @@
-﻿﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 COPY bin/release/net9.0/publish/ /app/bin/
 ENV TZ=Europe/London

--- a/src/Messaging.Host/Dockerfile
+++ b/src/Messaging.Host/Dockerfile
@@ -1,7 +1,6 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:7.0
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+﻿﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
-COPY bin/release/net7.0/publish/ /app/bin/
+COPY bin/release/net9.0/publish/ /app/bin/
 ENV TZ=Europe/London
 
 CMD dotnet /app/bin/Linn.Purchasing.Messaging.Host.dll

--- a/src/Messaging.Host/Messaging.Host.csproj
+++ b/src/Messaging.Host/Messaging.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Purchasing.Messaging.Host</AssemblyName>
 		<RootNamespace>Linn.Purchasing.Messaging.Host</RootNamespace>
 		<Nullable>enable</Nullable>

--- a/src/Messaging/Messaging.csproj
+++ b/src/Messaging/Messaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Messaging</AssemblyName>
     <RootNamespace>Linn.Purchasing.Messaging</RootNamespace>
   </PropertyGroup>

--- a/src/Persistence.LinnApps/Persistence.LinnApps.csproj
+++ b/src/Persistence.LinnApps/Persistence.LinnApps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Linn.Purchasing.Persistence.LinnApps</RootNamespace>
     <AssemblyName>Linn.Purchasing.Persistence.LinnApps</AssemblyName>
   </PropertyGroup>

--- a/src/Persistence.LinnApps/Repositories/SupplierSpendsRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/SupplierSpendsRepository.cs
@@ -8,6 +8,7 @@
     using Linn.Purchasing.Domain.LinnApps.Reports.Models;
 
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
     public class SupplierSpendRepository : IQueryRepository<SupplierSpend>
     {
@@ -25,7 +26,7 @@
 
         IQueryable<SupplierSpend> IQueryRepository<SupplierSpend>.FindAll()
         {
-            throw new NotImplementedException();
+            return this.serviceDbContext.SupplierSpends.AsNoTracking();
         }
 
         SupplierSpend IQueryRepository<SupplierSpend>.FindBy(Expression<Func<SupplierSpend, bool>> expression)

--- a/src/Persistence/Persistence.csproj
+++ b/src/Persistence/Persistence.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
 	<AssemblyName>Linn.Purchasing.Persistence</AssemblyName>
     <RootNamespace>Linn.Purchasing.Persistence</RootNamespace>
   </PropertyGroup>

--- a/src/Proxy/Proxy.csproj
+++ b/src/Proxy/Proxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Proxy</AssemblyName>
     <RootNamespace>Linn.Purchasing.Proxy</RootNamespace>
   </PropertyGroup>

--- a/src/Resources/Resources.csproj
+++ b/src/Resources/Resources.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Purchasing.Resources</AssemblyName>
 		<RootNamespace>Linn.Purchasing.Resources</RootNamespace>
 	</PropertyGroup>

--- a/src/Scheduling.Host/Dockerfile
+++ b/src/Scheduling.Host/Dockerfile
@@ -1,8 +1,7 @@
-FROM mcr.microsoft.com/dotnet/runtime:7.0
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 ENV TZ=Europe/London
 
-COPY /bin/release/net7.0/publish/ /app/bin/
+COPY /bin/release/net9.0/publish/ /app/bin/
 
 CMD dotnet /app/bin/Linn.Purchasing.Scheduling.Host.dll

--- a/src/Scheduling.Host/Scheduling.Host.csproj
+++ b/src/Scheduling.Host/Scheduling.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <RootNamespace>Linn.Purchasing.Scheduling.Host</RootNamespace>
     <AssemblyName>Linn.Purchasing.Scheduling.Host</AssemblyName>
 	  <Nullable>enable</Nullable>

--- a/src/Service.Host/Dockerfile
+++ b/src/Service.Host/Dockerfile
@@ -1,4 +1,4 @@
-﻿﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 ARG gitBranch=unspecified
 ENV TZ=Europe/London

--- a/src/Service.Host/Dockerfile
+++ b/src/Service.Host/Dockerfile
@@ -1,12 +1,11 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:7.0
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+﻿﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 ARG gitBranch=unspecified
 ENV TZ=Europe/London
 
 EXPOSE 5050
 
-COPY bin/release/net7.0/publish/ /app/bin/
+COPY bin/release/net9.0/publish/ /app/bin/
 COPY client/build/ /app/client/build/
 COPY views/ /app/views/
      

--- a/src/Service.Host/Service.Host.csproj
+++ b/src/Service.Host/Service.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Service.Host</AssemblyName>
     <RootNamespace>Linn.Purchasing.Service.Host</RootNamespace>
     <PreserveCompilationContext>true</PreserveCompilationContext>

--- a/src/Service.Host/client/src/components/reports/SpendBySupplierOptions.js
+++ b/src/Service.Host/client/src/components/reports/SpendBySupplierOptions.js
@@ -41,9 +41,9 @@ function SpendBySupplierReportOptions() {
         });
 
     return (
-        <Page history={history} homeUrl={config.appRoot} width="s">
+        <Page history={history} homeUrl={config.appRoot}>
             <Title text="Spend By Supplier" />
-            <Grid container spacing={3} justifyContent="center">
+            <Grid container spacing={3}>
                 {vendorManagersLoading ? (
                     <Grid item xs={12}>
                         <Loading />
@@ -77,9 +77,7 @@ function SpendBySupplierReportOptions() {
                                 onChange={(propertyName, newValue) => setVm(newValue)}
                             />
                         </Grid>
-
-                        <Grid item xs={12} />
-
+                        <Grid item xs={8} />
                         <Grid item xs={12}>
                             <Button color="primary" variant="contained" onClick={handleClick}>
                                 Run Report

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Service</AssemblyName>
     <RootNamespace>Linn.Purchasing.Service</RootNamespace>
   </PropertyGroup>

--- a/src/Tools/Tools.csproj
+++ b/src/Tools/Tools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/Integration/Integration.Scheduling.Tests/Integration.Scheduling.Tests.csproj
+++ b/tests/Integration/Integration.Scheduling.Tests/Integration.Scheduling.Tests.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssemblyName>Linn.Purchasing.Integration.Scheduling.Tests</AssemblyName>
 		<RootNamespace>Linn.Purchasing.Integration.Scheduling.Tests</RootNamespace>
 	</PropertyGroup>

--- a/tests/Integration/Integration.Tests/Integration.Tests.csproj
+++ b/tests/Integration/Integration.Tests/Integration.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Integration.Tests</AssemblyName>
     <RootNamespace>Linn.Purchasing.Integration.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit/Domain.LinnApps.Tests/Domain.LinnApps.Tests.csproj
+++ b/tests/Unit/Domain.LinnApps.Tests/Domain.LinnApps.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Domain.LinnApps.Tests</AssemblyName>
     <RootNamespace>Linn.Purchasing.Domain.LinnApps.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit/Domain.LinnApps.Tests/SpendsReportServiceTests/WhenGettingSupplierReport.cs
+++ b/tests/Unit/Domain.LinnApps.Tests/SpendsReportServiceTests/WhenGettingSupplierReport.cs
@@ -27,6 +27,8 @@
             var ledgerPeriodInLastYear = 1489;
             var ledgerPeriodInYearBeforeLast = 1479;
             var currentLedgerPeriod = 1500;
+            var aLongTimeAgo = 1400;
+
             var spends = new List<SupplierSpend>
                              {
                                  new SupplierSpend
@@ -68,6 +70,14 @@
                                          LedgerPeriod = currentLedgerPeriod,
                                          SupplierName = "seller1",
                                          VendorManager = "X"
+                                     },
+                                 new SupplierSpend
+                                     {
+                                         SupplierId = this.supplierId,
+                                         BaseTotal = 500000m,
+                                         LedgerPeriod = aLongTimeAgo, // should be ignored
+                                         SupplierName = "seller1",
+                                         VendorManager = "X"
                                      }
                              };
 
@@ -101,7 +111,7 @@
             var row = this.results.Rows.First();
             row.RowId.Should().Be(this.supplierId.ToString());
             this.results.GetGridTextValue(0, 0).Should().Be("seller1");
-            this.results.GetGridValue(0, 1).Should().Be(250.87m); // in 12 months before last FY, i.e. the fianacial year before last
+            this.results.GetGridValue(0, 1).Should().Be(250.87m); // in 12 months before last FY, i.e. the financial year before last
             this.results.GetGridValue(0, 2).Should().Be(240m);    // in last FY
             this.results.GetGridValue(0, 3).Should().Be(500m);     // in current period, i.e. this month
         }

--- a/tests/Unit/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Unit/Domain.Tests/Domain.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Domain.Tests</AssemblyName>
     <RootNamespace>Linn.Purchasing.Domain.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit/Facade.Tests/Facade.Tests.csproj
+++ b/tests/Unit/Facade.Tests/Facade.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Facade.Tests</AssemblyName>
     <RootNamespace>Linn.Purchasing.Facade.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit/Messaging.Tests/Messaging.Tests.csproj
+++ b/tests/Unit/Messaging.Tests/Messaging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Messaging.Tests</AssemblyName>
     <RootNamespace>Linn.Purchasing.Messaging.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Unit/Proxy.Tests/Proxy.Tests.csproj
+++ b/tests/Unit/Proxy.Tests/Proxy.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Linn.Purchasing.Proxy.Tests</AssemblyName>
     <RootNamespace>Linn.Purchasing.Proxy.Tests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
- quick report enhancement
- but also in keeping with my new rule (if you want to add an enhancement or new feature you also have to do some maintenance).... dotnet9.0 upgrade!
- Admittedly this is quite lowhanging fruit as far as maintenance is concerned - now that we dont have many non-dotnet depencies, upgrading seems as trivial as incrementing the target framework versions... let me know if you think I'm forgetting some subtleties 